### PR TITLE
Validate length prefixes before allocating in BitPacker deserialization

### DIFF
--- a/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
@@ -46,9 +46,8 @@ namespace PurrNet.Packing
         public bool isWriting => !_isReading;
 
 
-		public int remainingBytes => _isReading ? Math.Max(0, (isWrapper ? _wrapperEnd : _buffer.Length) - positionInBytes) : 0;
-
-		public long remainingBits => _isReading ? Math.Max(0L, (long)(isWrapper ? _wrapperEnd : _buffer.Length) * 8 - _positionInBits) : 0;
+		public int remainingBytes => Math.Max(0, (isWrapper ? _wrapperEnd : _buffer.Length) - positionInBytes);
+		public long remainingBits => Math.Max(0L, (long)(isWrapper ? _wrapperEnd : _buffer.Length) * 8 - _positionInBits);
 
 		private int _wrapperEnd;
 

--- a/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
@@ -48,7 +48,7 @@ namespace PurrNet.Packing
 
 		public int remainingBytes => _isReading ? Math.Max(0, (isWrapper ? _wrapperEnd : _buffer.Length) - positionInBytes) : 0;
 
-		public long remainingBits => (long)remainingBytes * 8;
+		public long remainingBits => _isReading ? Math.Max(0L, (long)(isWrapper ? _wrapperEnd : _buffer.Length) * 8 - _positionInBits) : 0;
 
 		private int _wrapperEnd;
 

--- a/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
@@ -46,12 +46,18 @@ namespace PurrNet.Packing
         public bool isWriting => !_isReading;
 
 
-		public int remainingBytes => Math.Max(0, (isWrapper ? _wrapperEnd : _buffer.Length) - positionInBytes);
-		public long remainingBits => Math.Max(0L, (long)(isWrapper ? _wrapperEnd : _buffer.Length) * 8 - _positionInBits);
+        public int remainingBytes => Math.Max(0, (isWrapper ? _wrapperEnd : (_isReading ? _writtenLength : _buffer.Length)) - positionInBytes);
+        public long remainingBits => Math.Max(0L, (long)(isWrapper ? _wrapperEnd : (_isReading ? _writtenLength : _buffer.Length)) * 8 - _positionInBits);
 
-		private int _wrapperEnd;
+        private int _wrapperEnd;
 
-		private int _wrapperStartBit;
+        private int _wrapperStartBit;
+
+        /// <summary>
+        /// Bytes written before switching to read mode. Bounds reads instead of the
+        /// pooled buffer's capacity, which can be much larger than the payload.
+        /// </summary>
+        private int _writtenLength;
 
         [UsedImplicitly, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AdvanceBit()
@@ -202,6 +208,9 @@ namespace PurrNet.Packing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetPositionAndMode(bool readMode)
         {
+            if (readMode && !_isReading && !isWrapper)
+                _writtenLength = positionInBytes;
+
             ResetPosition();
             _isReading = readMode;
         }
@@ -228,8 +237,11 @@ namespace PurrNet.Packing
 
             if (_isReading)
             {
-                if (requiredBytes > _buffer.Length)
-                    throw new IndexOutOfRangeException($"Not enough bits in the buffer. | {targetPos} > {_buffer.Length << 3}");
+				// A wrapper can be a slice of a larger pooled buffer
+				int limitBytes = isWrapper ? _wrapperEnd : _buffer.Length;
+
+                if (requiredBytes > limitBytes)
+                    throw new IndexOutOfRangeException($"Not enough bits in the buffer. | {targetPos} > {limitBytes << 3}");
                 return;
             }
 

--- a/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
@@ -254,8 +254,8 @@ namespace PurrNet.Packing
 
             if (_isReading)
             {
-				// A wrapper can be a slice of a larger pooled buffer
-				int limitBytes = isWrapper ? _wrapperEnd : _buffer.Length;
+                // A wrapper can be a slice of a larger pooled buffer
+                int limitBytes = isWrapper ? _wrapperEnd : _buffer.Length;
 
                 if (requiredBytes > limitBytes)
                     throw new IndexOutOfRangeException($"Not enough bits in the buffer. | {targetPos} > {limitBytes << 3}");
@@ -759,8 +759,8 @@ namespace PurrNet.Packing
             // Length
             int len = (int)ReadBits(31);
 
-			// len can't legitimately exceed what's left in the buffer
-			if (len < 0 || len > remainingBytes)
+            // len can't legitimately exceed what's left in the buffer
+            if (len < 0 || len > remainingBytes)
             {
                 throw new System.Runtime.Serialization.SerializationException(
                     $"Invalid string length during deserialization: {len}.");

--- a/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
@@ -46,8 +46,25 @@ namespace PurrNet.Packing
         public bool isWriting => !_isReading;
 
 
-        public int remainingBytes => Math.Max(0, (isWrapper ? _wrapperEnd : (_isReading ? _writtenLength : _buffer.Length)) - positionInBytes);
-        public long remainingBits => Math.Max(0L, (long)(isWrapper ? _wrapperEnd : (_isReading ? _writtenLength : _buffer.Length)) * 8 - _positionInBits);
+        public int remainingBytes
+        {
+            get
+            {
+                if (isWrapper) return Math.Max(0, _wrapperEnd - positionInBytes);
+                if (!_isReading) throw new InvalidOperationException("remainingBytes is only valid in read mode.");
+                return Math.Max(0, _writtenLength - positionInBytes);
+            }
+        }
+
+        public long remainingBits
+        {
+            get
+            {
+                if (isWrapper) return Math.Max(0L, (long)_wrapperEnd * 8 - _positionInBits);
+                if (!_isReading) throw new InvalidOperationException("remainingBits is only valid in read mode.");
+                return Math.Max(0L, (long)_writtenLength * 8 - _positionInBits);
+            }
+        }
 
         private int _wrapperEnd;
 

--- a/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
@@ -45,11 +45,14 @@ namespace PurrNet.Packing
 
         public bool isWriting => !_isReading;
 
-		/// <summary>
-		/// Bytes remaining in the buffer from the current read position.
-		/// Used to validate lengths before allocating for them.
-		/// </summary>
-		public int remainingBytes => _isReading ? Math.Max(0, _buffer.Length - positionInBytes) : 0;
+
+		public int remainingBytes => _isReading ? Math.Max(0, (isWrapper ? _wrapperEnd : _buffer.Length) - positionInBytes) : 0;
+
+		public long remainingBits => (long)remainingBytes * 8;
+
+		private int _wrapperEnd;
+
+		private int _wrapperStartBit;
 
         [UsedImplicitly, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AdvanceBit()
@@ -151,6 +154,8 @@ namespace PurrNet.Packing
         {
             _buffer = data.data;
             _positionInBits = data.offset * 8;
+            _wrapperStartBit = _positionInBits;
+            _wrapperEnd = data.offset + data.length;
             isWrapper = true;
         }
 
@@ -168,7 +173,7 @@ namespace PurrNet.Packing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetPosition()
         {
-            _positionInBits = 0;
+            _positionInBits = isWrapper ? _wrapperStartBit : 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -198,7 +203,7 @@ namespace PurrNet.Packing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetPositionAndMode(bool readMode)
         {
-            _positionInBits = 0;
+            ResetPosition();
             _isReading = readMode;
         }
 

--- a/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
@@ -45,6 +45,12 @@ namespace PurrNet.Packing
 
         public bool isWriting => !_isReading;
 
+		/// <summary>
+		/// Bytes remaining in the buffer from the current read position.
+		/// Used to validate lengths before allocating for them.
+		/// </summary>
+		public int remainingBytes => _isReading ? Math.Max(0, _buffer.Length - positionInBytes) : 0;
+
         [UsedImplicitly, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AdvanceBit()
         {
@@ -719,6 +725,13 @@ namespace PurrNet.Packing
 
             // Length
             int len = (int)ReadBits(31);
+
+			// len can't legitimately exceed what's left in the buffer
+			if (len < 0 || len > remainingBytes)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid string length during deserialization: {len}.");
+            }
 
             byte[] rented = null;
             Span<byte> temp = len <= 256

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
@@ -115,6 +115,14 @@ namespace PurrNet.Packing
             Size length = default;
             Packer<Size>.Read(packer, ref length);
             int lengthInt = (int)length.value;
+
+			// Untrusted length, check it fits
+			if (lengthInt < 0 || lengthInt > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid BitData length during deserialization: {length.value}.");
+            }
+
             int origin = packer.AdvanceBits(lengthInt);
             data = new BitData(packer, origin, lengthInt);
             packer.EnsurePadding();

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
@@ -25,6 +25,13 @@ namespace PurrNet.Packing
                 return;
             }
 
+			// Size is an unbounded uint, could otherwise request up to around 4GB
+			if (length.value > (uint)packer.remainingBytes)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid ByteData length during deserialization: {length.value}.");
+            }
+
             byte[] buffer = new byte[length];
             packer.ReadBytes(buffer);
             data = new ByteData(buffer, 0, (int)length.value);

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
@@ -68,6 +68,8 @@ namespace PurrNet.Packing
 
             var dest = data.GetSpan(length);
             packer.ReadBytes(dest);
+
+            data.AdvanceBytes(length);
             data.ResetPositionAndMode(true);
         }
 
@@ -93,7 +95,9 @@ namespace PurrNet.Packing
             var dataPacker = BitPackerPool.Get();
             var span = dataPacker.GetSpan(length);
             packer.ReadBytes(span);
-            dataPacker.ResetPosition();
+
+            dataPacker.AdvanceBytes(length);
+            dataPacker.ResetPositionAndMode(true);
 
             data = new BitPackerWithLength(length, dataPacker);
         }

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
@@ -25,7 +25,7 @@ namespace PurrNet.Packing
                 return;
             }
 
-			// Size is an unbounded uint, could otherwise request up to around 4GB
+			// Untrusted length. Check it fits before allocating
 			if (length.value > (uint)packer.remainingBytes)
             {
                 throw new System.Runtime.Serialization.SerializationException(
@@ -55,6 +55,13 @@ namespace PurrNet.Packing
             Size length = default;
             Packer<Size>.Read(packer, ref length);
 
+			// Untrusted length. Check it fits before allocating
+			if (length.value > (uint)packer.remainingBytes)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid BitPacker length during deserialization: {length.value}.");
+            }
+
             if (data == null)
                 data = BitPackerPool.Get();
             else data.ResetPositionAndMode(false);
@@ -75,6 +82,13 @@ namespace PurrNet.Packing
         {
             Size length = default;
             Packer<Size>.Read(packer, ref length);
+
+			// Untrusted length. Check it fits before allocating
+			if (length.value > (uint)packer.remainingBytes)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid BitPackerWithLength length during deserialization: {length.value}.");
+            }
 
             var dataPacker = BitPackerPool.Get();
             var span = dataPacker.GetSpan(length);

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackByteData.cs
@@ -6,6 +6,16 @@ namespace PurrNet.Packing
 {
     public static class PackByteData
     {
+        private static void ValidateByteLength(BitPacker packer, uint length, string typeName)
+        {
+            // Untrusted length. Check it fits before allocating
+            if (length > (uint)packer.remainingBytes)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid {typeName} length during deserialization: {length}.");
+            }
+        }
+
         [UsedByIL]
         public static void Write(this BitPacker packer, ByteData data)
         {
@@ -25,12 +35,7 @@ namespace PurrNet.Packing
                 return;
             }
 
-			// Untrusted length. Check it fits before allocating
-			if (length.value > (uint)packer.remainingBytes)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid ByteData length during deserialization: {length.value}.");
-            }
+            ValidateByteLength(packer, length.value, "ByteData");
 
             byte[] buffer = new byte[length];
             packer.ReadBytes(buffer);
@@ -55,12 +60,7 @@ namespace PurrNet.Packing
             Size length = default;
             Packer<Size>.Read(packer, ref length);
 
-			// Untrusted length. Check it fits before allocating
-			if (length.value > (uint)packer.remainingBytes)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid BitPacker length during deserialization: {length.value}.");
-            }
+            ValidateByteLength(packer, length.value, "BitPacker");
 
             if (data == null)
                 data = BitPackerPool.Get();
@@ -85,12 +85,7 @@ namespace PurrNet.Packing
             Size length = default;
             Packer<Size>.Read(packer, ref length);
 
-			// Untrusted length. Check it fits before allocating
-			if (length.value > (uint)packer.remainingBytes)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid BitPackerWithLength length during deserialization: {length.value}.");
-            }
+            ValidateByteLength(packer, length.value, "BitPackerWithLength");
 
             var dataPacker = BitPackerPool.Get();
             var span = dataPacker.GetSpan(length);
@@ -116,8 +111,8 @@ namespace PurrNet.Packing
             Packer<Size>.Read(packer, ref length);
             int lengthInt = (int)length.value;
 
-			// Untrusted length, check it fits
-			if (lengthInt < 0 || lengthInt > packer.remainingBits)
+            // Untrusted length, check it fits
+            if (lengthInt < 0 || lengthInt > packer.remainingBits)
             {
                 throw new System.Runtime.Serialization.SerializationException(
                     $"Invalid BitData length during deserialization: {length.value}.");

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
@@ -11,6 +11,8 @@ namespace PurrNet.Packing
 {
     public static class PackCollections
     {
+		private const int MAX_COLLECTION_ALLOCATION_BYTES = FragmentationLayer.MAX_MESSAGE_SIZE * 4;
+
         [UsedByIL]
         public static void RegisterHashSet<T>()
         {
@@ -202,7 +204,23 @@ namespace PurrNet.Packing
             if (!hasValue)
                 return;
 
-            int length = Packer<Size>.Read(packer);
+            uint rawLength = Packer<Size>.Read(packer);
+
+            // Can't fit more elements than bits remaining
+            if (rawLength > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid array length during deserialization: {rawLength}.");
+            }
+
+            // Also cap the actual allocation. Bit packed types can pass the check above
+            if (rawLength * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid array length during deserialization: {rawLength}.");
+            }
+
+            int length = (int)rawLength;
             value = DisposableArray<T>.Create(length);
 
             for (int i = 0; i < length; i++)
@@ -245,6 +263,21 @@ namespace PurrNet.Packing
             long length = default;
 
             packer.ReadInteger(ref length, 31);
+
+            // Can't fit more elements than bits remaining
+            if (length < 0 || length > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid hash set length during deserialization: {length}.");
+            }
+
+            // Also cap the actual allocation. Bit packed types can pass the check above
+            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid hash set length during deserialization: {length}.");
+            }
+
             value = DisposableHashSet<T>.Create((int)length);
 
             for (int i = 0; i < length; i++)
@@ -286,6 +319,20 @@ namespace PurrNet.Packing
             long length = default;
 
             packer.ReadInteger(ref length, 31);
+
+            // Can't fit more elements than bits remaining
+            if (length < 0 || length > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid queue length during deserialization: {length}.");
+            }
+
+            // Also cap the actual allocation. Bit packed types can pass the check above
+            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid queue length during deserialization: {length}.");
+            }
 
             if (value == null)
                 value = new Queue<T>((int)length);
@@ -330,6 +377,20 @@ namespace PurrNet.Packing
             long length = default;
 
             packer.ReadInteger(ref length, 31);
+
+            // Can't fit more elements than bits remaining
+            if (length < 0 || length > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid stack length during deserialization: {length}.");
+            }
+
+            // Also cap the actual allocation. Bit packed types can pass the check above
+            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid stack length during deserialization: {length}.");
+            }
 
             if (value == null)
                 value = new Stack<T>((int)length);
@@ -377,6 +438,20 @@ namespace PurrNet.Packing
             long length = default;
 
             packer.ReadInteger(ref length, 31);
+
+            // Can't fit more entries than bits remaining
+            if (length < 0 || length > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid dictionary length during deserialization: {length}.");
+            }
+
+            // Also cap the actual allocation. Bit packed types can pass the check above
+            if (length * (long)(Unsafe.SizeOf<K>() + Unsafe.SizeOf<V>()) > MAX_COLLECTION_ALLOCATION_BYTES)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid dictionary length during deserialization: {length}.");
+            }
 
             if (value == null)
                 value = new Dictionary<K, V>((int)length);
@@ -466,6 +541,20 @@ namespace PurrNet.Packing
 
             packer.ReadInteger(ref length, 31);
 
+            // Can't fit more elements than bits remaining
+            if (length < 0 || length > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid hash set length during deserialization: {length}.");
+            }
+
+            // Also cap the actual allocation. Bit packed types can pass the check above
+            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid hash set length during deserialization: {length}.");
+            }
+
             if (value == null)
                 value = new HashSet<T>((int)length);
             else value.Clear();
@@ -519,6 +608,20 @@ namespace PurrNet.Packing
 
             packer.ReadInteger(ref length, 31);
 
+            // Can't fit more elements than bits remaining
+            if (length < 0 || length > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid list length during deserialization: {length}.");
+            }
+
+            // Also cap the actual allocation. Bit packed types can pass the check above
+            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid list length during deserialization: {length}.");
+            }
+
             if (value == null)
                 value = new List<T>((int)length);
             else value.Clear();
@@ -530,9 +633,6 @@ namespace PurrNet.Packing
                 value.Add(item);
             }
         }
-
-        // Seperate from MAX_MESSAGE_SIZE since bit backed types can exeed it here
-        private const int MAX_ARRAY_ALLOCATION_BYTES = FragmentationLayer.MAX_MESSAGE_SIZE * 4;
 
         [UsedByIL]
         public static void ReadArray<T>(this BitPacker packer, ref T[] value)
@@ -564,7 +664,7 @@ namespace PurrNet.Packing
             }
 
             // Also cap the actual allocation. Bit packed types can pass the check above
-            if (length * (long)Unsafe.SizeOf<T>() > MAX_ARRAY_ALLOCATION_BYTES)
+            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
             {
                 throw new System.Runtime.Serialization.SerializationException(
                     $"Invalid array length during deserialization: {length}.");

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
@@ -531,6 +531,9 @@ namespace PurrNet.Packing
             }
         }
 
+        // Seperate from MAX_MESSAGE_SIZE since bit backed types can exeed it here
+        private const int MAX_ARRAY_ALLOCATION_BYTES = FragmentationLayer.MAX_MESSAGE_SIZE * 4;
+
         [UsedByIL]
         public static void ReadArray<T>(this BitPacker packer, ref T[] value)
         {
@@ -553,9 +556,15 @@ namespace PurrNet.Packing
                 return;
             }
 
-			// bound the allocation, not just the length
-            // T's serialized size can be smaller than sizeof(T)
-			if (length < 0 || length * (long)Unsafe.SizeOf<T>() > FragmentationLayer.MAX_MESSAGE_SIZE)
+            // Can't fit more elements than bits remaining
+            if (length < 0 || length > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid array length during deserialization: {length}.");
+            }
+
+            // Also cap the actual allocation. Bit packed types can pass the check above
+            if (length * (long)Unsafe.SizeOf<T>() > MAX_ARRAY_ALLOCATION_BYTES)
             {
                 throw new System.Runtime.Serialization.SerializationException(
                     $"Invalid array length during deserialization: {length}.");

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
@@ -551,6 +551,13 @@ namespace PurrNet.Packing
                 return;
             }
 
+			// Each element needs at least 1 byte to encode
+			if (length < 0 || length > packer.remainingBytes)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid array length during deserialization: {length}.");
+            }
+
             if (value == null)
                 value = new T[length];
             else if (value.Length != length)

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using PurrNet.Modules;
 using PurrNet.Pooling;
+using PurrNet.Transports;
 using UnityEngine;
 using Unity.Collections;
 
@@ -551,8 +553,9 @@ namespace PurrNet.Packing
                 return;
             }
 
-			// Elements can be smaller than a byte so bound against bits
-			if (length < 0 || length > packer.remainingBits)
+			// bound the allocation, not just the length
+            // T's serialized size can be smaller than sizeof(T)
+			if (length < 0 || length * (long)Unsafe.SizeOf<T>() > FragmentationLayer.MAX_MESSAGE_SIZE)
             {
                 throw new System.Runtime.Serialization.SerializationException(
                     $"Invalid array length during deserialization: {length}.");

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
@@ -11,7 +11,24 @@ namespace PurrNet.Packing
 {
     public static class PackCollections
     {
-		private const int MAX_COLLECTION_ALLOCATION_BYTES = FragmentationLayer.MAX_MESSAGE_SIZE * 4;
+        private const int MAX_COLLECTION_ALLOCATION_BYTES = FragmentationLayer.MAX_MESSAGE_SIZE * 4;
+
+        private static void ValidateCollectionLength(long length, BitPacker packer, long elementSize, string typeName)
+        {
+            // Can't fit more elements than bits remaining
+            if (length < 0 || length > packer.remainingBits)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid {typeName} length during deserialization: {length}.");
+            }
+
+            // Also cap the actual allocation. Bit packed types can pass the check above
+            if (length * elementSize > MAX_COLLECTION_ALLOCATION_BYTES)
+            {
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid {typeName} length during deserialization: {length}.");
+            }
+        }
 
         [UsedByIL]
         public static void RegisterHashSet<T>()
@@ -206,19 +223,7 @@ namespace PurrNet.Packing
 
             uint rawLength = Packer<Size>.Read(packer);
 
-            // Can't fit more elements than bits remaining
-            if (rawLength > packer.remainingBits)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid array length during deserialization: {rawLength}.");
-            }
-
-            // Also cap the actual allocation. Bit packed types can pass the check above
-            if (rawLength * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid array length during deserialization: {rawLength}.");
-            }
+            ValidateCollectionLength(rawLength, packer, Unsafe.SizeOf<T>(), "array");
 
             int length = (int)rawLength;
             value = DisposableArray<T>.Create(length);
@@ -264,19 +269,7 @@ namespace PurrNet.Packing
 
             packer.ReadInteger(ref length, 31);
 
-            // Can't fit more elements than bits remaining
-            if (length < 0 || length > packer.remainingBits)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid hash set length during deserialization: {length}.");
-            }
-
-            // Also cap the actual allocation. Bit packed types can pass the check above
-            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid hash set length during deserialization: {length}.");
-            }
+            ValidateCollectionLength(length, packer, Unsafe.SizeOf<T>(), "hash set");
 
             value = DisposableHashSet<T>.Create((int)length);
 
@@ -320,19 +313,7 @@ namespace PurrNet.Packing
 
             packer.ReadInteger(ref length, 31);
 
-            // Can't fit more elements than bits remaining
-            if (length < 0 || length > packer.remainingBits)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid queue length during deserialization: {length}.");
-            }
-
-            // Also cap the actual allocation. Bit packed types can pass the check above
-            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid queue length during deserialization: {length}.");
-            }
+            ValidateCollectionLength(length, packer, Unsafe.SizeOf<T>(), "queue");
 
             if (value == null)
                 value = new Queue<T>((int)length);
@@ -378,19 +359,7 @@ namespace PurrNet.Packing
 
             packer.ReadInteger(ref length, 31);
 
-            // Can't fit more elements than bits remaining
-            if (length < 0 || length > packer.remainingBits)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid stack length during deserialization: {length}.");
-            }
-
-            // Also cap the actual allocation. Bit packed types can pass the check above
-            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid stack length during deserialization: {length}.");
-            }
+            ValidateCollectionLength(length, packer, Unsafe.SizeOf<T>(), "stack");
 
             if (value == null)
                 value = new Stack<T>((int)length);
@@ -439,19 +408,7 @@ namespace PurrNet.Packing
 
             packer.ReadInteger(ref length, 31);
 
-            // Can't fit more entries than bits remaining
-            if (length < 0 || length > packer.remainingBits)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid dictionary length during deserialization: {length}.");
-            }
-
-            // Also cap the actual allocation. Bit packed types can pass the check above
-            if (length * (long)(Unsafe.SizeOf<K>() + Unsafe.SizeOf<V>()) > MAX_COLLECTION_ALLOCATION_BYTES)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid dictionary length during deserialization: {length}.");
-            }
+            ValidateCollectionLength(length, packer, Unsafe.SizeOf<K>() + Unsafe.SizeOf<V>(), "dictionary");
 
             if (value == null)
                 value = new Dictionary<K, V>((int)length);
@@ -541,19 +498,7 @@ namespace PurrNet.Packing
 
             packer.ReadInteger(ref length, 31);
 
-            // Can't fit more elements than bits remaining
-            if (length < 0 || length > packer.remainingBits)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid hash set length during deserialization: {length}.");
-            }
-
-            // Also cap the actual allocation. Bit packed types can pass the check above
-            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid hash set length during deserialization: {length}.");
-            }
+            ValidateCollectionLength(length, packer, Unsafe.SizeOf<T>(), "hash set");
 
             if (value == null)
                 value = new HashSet<T>((int)length);
@@ -608,19 +553,7 @@ namespace PurrNet.Packing
 
             packer.ReadInteger(ref length, 31);
 
-            // Can't fit more elements than bits remaining
-            if (length < 0 || length > packer.remainingBits)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid list length during deserialization: {length}.");
-            }
-
-            // Also cap the actual allocation. Bit packed types can pass the check above
-            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid list length during deserialization: {length}.");
-            }
+            ValidateCollectionLength(length, packer, Unsafe.SizeOf<T>(), "list");
 
             if (value == null)
                 value = new List<T>((int)length);
@@ -656,19 +589,7 @@ namespace PurrNet.Packing
                 return;
             }
 
-            // Can't fit more elements than bits remaining
-            if (length < 0 || length > packer.remainingBits)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid array length during deserialization: {length}.");
-            }
-
-            // Also cap the actual allocation. Bit packed types can pass the check above
-            if (length * (long)Unsafe.SizeOf<T>() > MAX_COLLECTION_ALLOCATION_BYTES)
-            {
-                throw new System.Runtime.Serialization.SerializationException(
-                    $"Invalid array length during deserialization: {length}.");
-            }
+            ValidateCollectionLength(length, packer, Unsafe.SizeOf<T>(), "array");
 
             if (value == null)
                 value = new T[length];

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackCollections.cs
@@ -551,8 +551,8 @@ namespace PurrNet.Packing
                 return;
             }
 
-			// Each element needs at least 1 byte to encode
-			if (length < 0 || length > packer.remainingBytes)
+			// Elements can be smaller than a byte so bound against bits
+			if (length < 0 || length > packer.remainingBits)
             {
                 throw new System.Runtime.Serialization.SerializationException(
                     $"Invalid array length during deserialization: {length}.");

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncEvent.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncEvent.cs
@@ -29,7 +29,7 @@ namespace PurrNet
 
         public void ResetPosition()
         {
-            _dataPacker?.ResetPosition();
+            _dataPacker?.ResetPositionAndMode(true);
         }
 
         public void Dispose()

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/RpcRequestResponseModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/RpcRequestResponseModule.cs
@@ -188,7 +188,8 @@ namespace PurrNet.Modules
                     {
                         using var stream = RPCModule.AllocStream(false);
                         stream.WriteBytes(data.data);
-                        stream.ResetPosition();
+						// Untrusted bytes. Enter read mode before reading so length checks aren't bypassed
+						stream.ResetPositionAndMode(true);
 
                         request.completer.Respond(stream);
                     }

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/RpcRequestResponseModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/RpcRequestResponseModule.cs
@@ -188,8 +188,8 @@ namespace PurrNet.Modules
                     {
                         using var stream = RPCModule.AllocStream(false);
                         stream.WriteBytes(data.data);
-						// Untrusted bytes. Enter read mode before reading so length checks aren't bypassed
-						stream.ResetPositionAndMode(true);
+                        // Untrusted bytes. Enter read mode before reading so length checks aren't bypassed
+                        stream.ResetPositionAndMode(true);
 
                         request.completer.Respond(stream);
                     }

--- a/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
+++ b/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
@@ -559,6 +559,31 @@ public class BitPackerEdgeCaseTests
 	}
 
 	[Test]
+	public void WriteBytes_ThenSwitchToReadMode_RejectsMalformedLengthPrefix()
+	{
+		_packer.ResetPositionAndMode(false);
+		_packer.WriteBit(true); // has value
+		_packer.WriteBits(1_000_000, 31); // claimed length, no payload follows
+		_packer.ResetPositionAndMode(true);
+
+		Assert.Throws<System.Runtime.Serialization.SerializationException>(
+			() => _packer.ReadString(System.Text.Encoding.UTF8));
+	}
+
+	[Test]
+	public void BareResetPosition_LeavesWriteModeAndReadThrows()
+	{
+		_packer.ResetPositionAndMode(false);
+		_packer.WriteBit(true);
+		_packer.WriteBits(1_000_000, 31);
+		_packer.ResetPosition();
+
+		Assert.IsFalse(_packer.isReading);
+		Assert.Throws<InvalidOperationException>(
+			() => _packer.ReadString(System.Text.Encoding.UTF8));
+	}
+
+	[Test]
 	public void ReadString_WrapperInsideBiggerBackingArrayRejectsLengthPastRealPacket()
 	{
 		var writer = BitPackerPool.Get();

--- a/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
+++ b/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
@@ -530,7 +530,57 @@ public class BitPackerEdgeCaseTests
         writer.Dispose();
     }
 
-    [Test]
+	[Test]
+	public void ReadArray_LargeBoolArrayRoundtripsWithoutFalseRejection()
+	{
+		var expected = new bool[1000];
+		for (int i = 0; i < expected.Length; i++)
+			expected[i] = i % 3 == 0;
+
+		var writer = BitPackerPool.Get();
+		writer.ResetPositionAndMode(false);
+		writer.WriteList<bool>(expected);
+
+		// writer.buffer can be bigger than writer.length. Trim to the real size
+		var trimmed = new byte[writer.length];
+		Array.Copy(writer.buffer, trimmed, trimmed.Length);
+
+		_packer.MakeWrapper(new ByteData(trimmed, 0, trimmed.Length));
+		_packer.ResetPositionAndMode(true);
+
+		bool[] result = null;
+		Assert.DoesNotThrow(() => _packer.ReadArray(ref result));
+
+		Assert.AreEqual(expected.Length, result.Length);
+		for (int i = 0; i < expected.Length; i++)
+			Assert.AreEqual(expected[i], result[i], $"Element {i}");
+
+		writer.Dispose();
+	}
+
+	[Test]
+	public void ReadString_WrapperInsideBiggerBackingArrayRejectsLengthPastRealPacket()
+	{
+		var writer = BitPackerPool.Get();
+		writer.ResetPositionAndMode(false);
+		writer.WriteBit(true); // has value
+		writer.WriteBits(1_000_000, 31); // claimed length, no payload follows
+
+		// Small packet inside a much bigger backing array, like a pooled buffer
+		var wrapped = WithOffset(writer.buffer, 16);
+		var padded = new byte[wrapped.data.Length + 2_000_000];
+		Buffer.BlockCopy(wrapped.data, 0, padded, 0, wrapped.data.Length);
+
+		_packer.MakeWrapper(new ByteData(padded, wrapped.offset, wrapped.length));
+		_packer.ResetPositionAndMode(true);
+
+		Assert.Throws<System.Runtime.Serialization.SerializationException>(
+			() => _packer.ReadString(System.Text.Encoding.UTF8));
+
+		writer.Dispose();
+	}
+
+	[Test]
     public void FragmentationLayer_MaximumFragmentCountBoundaryRoundtrips()
     {
         const int mtu = 24;

--- a/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
+++ b/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
@@ -474,6 +474,62 @@ public class BitPackerEdgeCaseTests
         Assert.AreEqual(0, receiver.pendingBytes);
     }
 
+	[Test]
+    public void ReadString_MalformedLengthIsRejectedBeforeAllocating()
+    {
+        var writer = BitPackerPool.Get();
+        writer.ResetPositionAndMode(false);
+        writer.WriteBit(true); // has value
+        writer.WriteBits(1_000_000, 31); // claimed length, no payload follows
+
+        _packer.MakeWrapper(new ByteData(writer.buffer, 0, writer.length));
+        _packer.ResetPositionAndMode(true);
+
+        Assert.Throws<System.Runtime.Serialization.SerializationException>(
+            () => _packer.ReadString(System.Text.Encoding.UTF8));
+
+        writer.Dispose();
+    }
+
+	[Test]
+    public void ReadArray_MalformedLengthIsRejectedBeforeAllocating()
+    {
+        var writer = BitPackerPool.Get();
+        writer.ResetPositionAndMode(false);
+        writer.WriteBit(true); // has value
+        writer.WriteBits(1_000_000, 31); // claimed length, no elements follow
+
+        _packer.MakeWrapper(new ByteData(writer.buffer, 0, writer.length));
+        _packer.ResetPositionAndMode(true);
+
+        int[] result = null;
+        Assert.Throws<System.Runtime.Serialization.SerializationException>(
+            () => _packer.ReadArray(ref result));
+
+        writer.Dispose();
+    }
+
+	[Test]
+    public void ByteData_MalformedLengthIsRejectedBeforeAllocating()
+    {
+        var writer = BitPackerPool.Get();
+        writer.ResetPositionAndMode(false);
+        writer.Write(new ByteData(new byte[64], 0, 64));
+
+		// Keep only the length header, drop the payload
+		var truncated = new byte[8];
+        Array.Copy(writer.buffer, truncated, truncated.Length);
+
+        _packer.MakeWrapper(new ByteData(truncated, 0, truncated.Length));
+        _packer.ResetPositionAndMode(true);
+
+        var result = default(ByteData);
+        Assert.Throws<System.Runtime.Serialization.SerializationException>(
+            () => _packer.Read(ref result));
+
+        writer.Dispose();
+    }
+
     [Test]
     public void FragmentationLayer_MaximumFragmentCountBoundaryRoundtrips()
     {


### PR DESCRIPTION
Fixes unvalidated length prefix DoS in BitPacker deserialization. There were places allocating a buffer sized from an untrusted length before checking it fit in the remaining data. Added checks that reject a length that can't fit before allocating, capped with MAX_COLLECTION_ALLOCATION_BYTES

Also fixed RpcRequestResponseModule/SyncEventData calling  ResetPosition() before reading and not flipping _isReading, so the read happened in write mode and skipped the checks. Now uses ResetPositionAndMode(true).

Added tests for all of this.