### PR TITLE
Fixed SyncVar GC spikes from tick sub/unsub

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/IPlayerEvents.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/IPlayerEvents.cs
@@ -9,6 +9,25 @@
         void OnTick(float delta);
     }
 
+    public interface IBaseTickListener
+    {
+    }
+
+    public interface ITickListener : IBaseTickListener
+    {
+        void OnTick();
+    }
+
+    public interface IPreTickListener : IBaseTickListener
+    {
+        void OnPreTick();
+    }
+
+    public interface IPostTickListener : IBaseTickListener
+    {
+        void OnPostTick();
+    }
+
     public interface IPlayerEvents
     {
         void OnPlayerConnected(PlayerID playerId, bool isReconnect, bool asServer);

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
@@ -10,7 +10,7 @@ using PurrNet.Utils;
 namespace PurrNet
 {
     [Serializable]
-    public class SyncVar<T> : NetworkModule, ISerializationCallbackReceiver
+    public class SyncVar<T> : NetworkModule, ISerializationCallbackReceiver, ITickListener
     {
         private TickManager _tickManager;
 
@@ -122,7 +122,7 @@ namespace PurrNet
 
             _isSubscribedToTickManager = true;
             _subscribedTicker = networkManager.tickModule;
-            _subscribedTicker.onTick += OnTick;
+            _subscribedTicker.AddTickListener(this);
         }
 
         private void UnsubscribeFromTickManager()
@@ -131,7 +131,7 @@ namespace PurrNet
                 return;
 
             _isSubscribedToTickManager = false;
-            _subscribedTicker.onTick -= OnTick;
+            _subscribedTicker.RemoveTickListener(this);
         }
 
         public override void OnInitializeModules()

--- a/Assets/PurrNet/Runtime/CoreModules/Ticks/TickManager.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Ticks/TickManager.cs
@@ -1,6 +1,7 @@
 using System;
 using PurrNet.Packing;
 using PurrNet.Transports;
+using PurrNet.Utils;
 using UnityEngine;
 
 namespace PurrNet.Modules
@@ -71,6 +72,8 @@ namespace PurrNet.Modules
 
         public event Action onPreTick, onTick, onPostTick;
         public event Action onReliablePreTick, onReliableTick, onReliablePostTick;
+
+        private readonly PurrAction<ITickListener> _tickListeners = new(static listener => listener.OnTick(), 256);
 
         /// <summary>
         /// Lower clamp for <see cref="tickPacingScale"/>.
@@ -211,7 +214,10 @@ namespace PurrNet.Modules
                 onReliablePreTick?.Invoke();
 
                 if (triggerNormalTicks)
+                {
                     onTick?.Invoke();
+                    _tickListeners.Invoke();
+                }
                 onReliableTick?.Invoke();
 
                 if (triggerNormalTicks)
@@ -220,6 +226,16 @@ namespace PurrNet.Modules
 
                 ticksHandled++;
             }
+        }
+        
+        public void AddTickListener(ITickListener listener)
+        {
+            _tickListeners.Add(listener);
+        }
+        
+        public void RemoveTickListener(ITickListener listener)
+        {
+            _tickListeners.Remove(listener);
         }
 
         /// <summary>

--- a/Assets/PurrNet/Runtime/Utils/PurrAction.cs
+++ b/Assets/PurrNet/Runtime/Utils/PurrAction.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+
+namespace PurrNet.Utils
+{
+    public sealed class PurrAction<T> where T : class, IBaseTickListener
+    {
+        private readonly List<T> _listeners;
+        private readonly System.Action<T> _invoke;
+        private bool _isInvoking;
+
+        public PurrAction(System.Action<T> invoke, int capacity = 0)
+        {
+            _listeners = new List<T>(capacity);
+            _invoke = invoke;
+        }
+
+        public void Add(T listener)
+        {
+            _listeners.Add(listener);
+        }
+
+        public void Remove(T listener)
+        {
+            for (var i = _listeners.Count - 1; i >= 0; i--)
+            {
+                if (_listeners[i] != listener)
+                    continue;
+
+                if (_isInvoking)
+                    _listeners[i] = null;
+                else
+                    _listeners.RemoveAt(i);
+
+                return;
+            }
+        }
+
+        public void Invoke()
+        {
+            var count = _listeners.Count;
+            _isInvoking = true;
+
+            try
+            {
+                for (var i = 0; i < count; i++)
+                {
+                    var listener = _listeners[i];
+                    if (listener != null)
+                        _invoke(listener);
+                }
+            }
+            finally
+            {
+                _isInvoking = false;
+                Compact();
+            }
+        }
+
+        private void Compact()
+        {
+            var writeIndex = 0;
+
+            for (var readIndex = 0; readIndex < _listeners.Count; readIndex++)
+            {
+                var listener = _listeners[readIndex];
+                if (listener == null)
+                    continue;
+
+                _listeners[writeIndex++] = listener;
+            }
+
+            if (writeIndex < _listeners.Count)
+                _listeners.RemoveRange(writeIndex, _listeners.Count - writeIndex);
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/Utils/PurrAction.cs.meta
+++ b/Assets/PurrNet/Runtime/Utils/PurrAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f5e6a5b1d5f4e2f9a7d3b8c6e1f204a


### PR DESCRIPTION
I made this PR to fix GC spikes from frequent SyncVar tick subscribe/unsubscribe calls.

Created PurrAction with a static invoker so the same dispatch logic can be reused for OnTick, OnPreTick, and OnPostTick in the future, while still keeping FIFO order and safe removal.

I avoided using a list of Actions because multicast doesn't really make sense for tick listeners and would make logic way more complex than it should be when making custom invocation wrapper. Interface-based listeners make the intent clearer and prevent that kind of misuse.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789561130&installation_model_id=20441&pr_number=300&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F300&signature=bc14bcfd7b0e1e55f066ca7a744ced6dffbb8e6a1c3cba3fd85abe22c5bd9fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->