### PR TITLE
fix: Performance boost for new PurrAction

### DIFF
--- a/Assets/PurrNet/Runtime/Utils/PurrAction.cs
+++ b/Assets/PurrNet/Runtime/Utils/PurrAction.cs
@@ -1,44 +1,56 @@
-using System.Collections.Generic;
+using System;
+using System.Runtime.CompilerServices;
 
 namespace PurrNet.Utils
 {
     public sealed class PurrAction<T> where T : class, IBaseTickListener
     {
-        private readonly List<T> _listeners;
-        private readonly System.Action<T> _invoke;
-        private bool _isInvoking;
+        private const int MinNullsBeforeCompact = 8;
 
-        public PurrAction(System.Action<T> invoke, int capacity = 0)
+        private T[] _listeners;
+        private int _count;
+        private int _nullCount;
+        private int _invokeDepth;
+        private readonly Action<T> _invoke;
+
+        public int Count => _count - _nullCount;
+
+        public PurrAction(Action<T> invoke, int capacity = 0)
         {
-            _listeners = new List<T>(capacity);
             _invoke = invoke;
+            _listeners = capacity > 0 ? new T[capacity] : Array.Empty<T>();
         }
 
         public void Add(T listener)
         {
-            _listeners.Add(listener);
+            if (_invokeDepth == 0 && ShouldCompact())
+                Compact();
+
+            if (_count == _listeners.Length)
+                EnsureCapacity();
+
+            _listeners[_count++] = listener;
         }
 
         public void Remove(T listener)
         {
-            for (var i = _listeners.Count - 1; i >= 0; i--)
+            var listeners = _listeners;
+
+            for (var i = _count - 1; i >= 0; i--)
             {
-                if (_listeners[i] != listener)
+                if (listeners[i] != listener)
                     continue;
 
-                if (_isInvoking)
-                    _listeners[i] = null;
-                else
-                    _listeners.RemoveAt(i);
-
+                listeners[i] = null;
+                _nullCount++;
                 return;
             }
         }
 
         public void Invoke()
         {
-            var count = _listeners.Count;
-            _isInvoking = true;
+            var count = _count;
+            _invokeDepth++;
 
             try
             {
@@ -51,26 +63,73 @@ namespace PurrNet.Utils
             }
             finally
             {
-                _isInvoking = false;
-                Compact();
+                if (--_invokeDepth == 0 && _nullCount > 0)
+                    Compact();
             }
+        }
+
+        /// <summary>Force reclamation of removed slots. No-op during dispatch.</summary>
+        public void CompactNow()
+        {
+            if (_invokeDepth == 0 && _nullCount > 0)
+                Compact();
+        }
+
+        public void Clear()
+        {
+            if (_invokeDepth > 0)
+            {
+
+                for (var i = 0; i < _count; i++)
+                {
+                    if (_listeners[i] == null)
+                        continue;
+
+                    _listeners[i] = null;
+                    _nullCount++;
+                }
+                return;
+            }
+
+            Array.Clear(_listeners, 0, _count);
+            _count = 0;
+            _nullCount = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool ShouldCompact()
+        {
+            return _nullCount >= MinNullsBeforeCompact && _nullCount * 2 >= _count;
+        }
+
+        private void EnsureCapacity()
+        {
+            if (_invokeDepth == 0 && _nullCount > 0)
+            {
+                Compact();
+                if (_count < _listeners.Length)
+                    return;
+            }
+
+            Array.Resize(ref _listeners, _listeners.Length == 0 ? 4 : _listeners.Length * 2);
         }
 
         private void Compact()
         {
-            var writeIndex = 0;
+            var listeners = _listeners;
+            var count = _count;
+            var write = 0;
 
-            for (var readIndex = 0; readIndex < _listeners.Count; readIndex++)
+            for (var read = 0; read < count; read++)
             {
-                var listener = _listeners[readIndex];
-                if (listener == null)
-                    continue;
-
-                _listeners[writeIndex++] = listener;
+                var listener = listeners[read];
+                if (listener != null)
+                    listeners[write++] = listener;
             }
 
-            if (writeIndex < _listeners.Count)
-                _listeners.RemoveRange(writeIndex, _listeners.Count - writeIndex);
+            Array.Clear(listeners, write, count - write);
+            _count = write;
+            _nullCount = 0;
         }
     }
 }

--- a/Assets/PurrNet/Runtime/Utils/PurrAction.cs
+++ b/Assets/PurrNet/Runtime/Utils/PurrAction.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace PurrNet.Utils
 {
-    public sealed class PurrAction<T> where T : class, IBaseTickListener
+    public sealed class PurrAction<T> where T : class
     {
         private const int MinNullsBeforeCompact = 8;
 
@@ -23,7 +23,6 @@ namespace PurrNet.Utils
 
         public void Add(T listener)
         {
-            // a null slot is a tombstone, so it must never enter as a live entry
             if (listener == null)
                 return;
 
@@ -38,7 +37,6 @@ namespace PurrNet.Utils
 
         public void Remove(T listener)
         {
-            // would otherwise match an existing tombstone and double-count it
             if (listener == null)
                 return;
 

--- a/Assets/PurrNet/Runtime/Utils/PurrAction.cs
+++ b/Assets/PurrNet/Runtime/Utils/PurrAction.cs
@@ -23,6 +23,10 @@ namespace PurrNet.Utils
 
         public void Add(T listener)
         {
+            // a null slot is a tombstone, so it must never enter as a live entry
+            if (listener == null)
+                return;
+
             if (_invokeDepth == 0 && ShouldCompact())
                 Compact();
 
@@ -34,6 +38,10 @@ namespace PurrNet.Utils
 
         public void Remove(T listener)
         {
+            // would otherwise match an existing tombstone and double-count it
+            if (listener == null)
+                return;
+
             var listeners = _listeners;
 
             for (var i = _count - 1; i >= 0; i--)


### PR DESCRIPTION
PurrAction<T> Benchmark: Original vs Optimized
Listeners = 500, Ticks = 20,000

--- 1) Steady-state (no churn) ---
  Original :    209 ms
  Optimized:     78 ms
  Speedup  : 2.66x

--- 2) Interleaved churn (add+remove every tick) ---
  Original :    252 ms
  Optimized:    159 ms
  Speedup  : 1.59x

--- 3) Burst removal (remove half at once, then tick) ---
  Original :    215 ms
  Optimized:     85 ms
  Speedup  : 2.51x

Changes:

Swapped List<T> for a raw T[] array — avoids the extra overhead of list indexing in the hot dispatch loop. Skip compacting when nothing was removed — the original ran a full cleanup pass every single tick, even when there was nothing to clean up. Now it only compacts when needed. Fixed a re-entrancy bug — if a listener triggered another tick while one was already running, the old bool flag would get cleared too early and corrupt the loop (skipping or double-firing listeners). Replaced with a counter that handles nested calls correctly. Made removal instant when not ticking — removing a listener outside of a tick used to shift the whole array down. Now it's deferred (marked dead, cleaned up later) so it's cheap even in bursts. Guaranteed listener order is preserved — made sure removals never reorder the remaining listeners, so they always fire in the order they registered. Added a threshold before cleaning up dead slots — instead of cleaning up after every single removal, it now waits until enough dead slots pile up (both a minimum count and a proportion of the array) before bothering to compact. This avoids wasted work on small, infrequent changes. Reuse dead slots before growing the array — when adding a new listener and the array is full, it first tries to reclaim space from removed listeners instead of immediately allocating more memory. Added a manual cleanup option (CompactNow) — for cases where a group of listeners is registered but rarely or never actually ticks, so dead slots don't sit around forever. Made Clear() safe during an active tick — it now defers clearing if a tick is in progress, instead of ripping out entries mid-loop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789575500&installation_model_id=20441&pr_number=301&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F301&signature=bf863c4923181639f9b5a597201f0d93f024fc0ca348414831bc21e25d3fe2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->