### PR TITLE
Got rid of native update overhead

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
@@ -359,6 +359,8 @@ namespace PurrNet
         public Quaternion rotation { get; private set; }
         public Vector3 localScale { get; private set; }
 
+        private Action _onUpdate;
+        private Action _onLateUpdate;
         private Action _onLateLateUpdate;
 #if UNITY_PHYSICS_3D || UNITY_PHYSICS_2D
         private Action _onLateFixedUpdate;
@@ -387,6 +389,8 @@ namespace PurrNet
 
         private void Awake()
         {
+            _onUpdate = OnUpdate;
+            _onLateUpdate = OnLateUpdate;
             _onLateLateUpdate = LateLateUpdate;
 #if UNITY_PHYSICS_3D || UNITY_PHYSICS_2D
             _onLateFixedUpdate = LateFixedUpdate;
@@ -411,6 +415,8 @@ namespace PurrNet
         private void OnEnable()
         {
             CacheCurrentPose();
+            UnityUpdate.onUpdate += _onUpdate;
+            UnityUpdate.onLateUpdate += _onLateUpdate;
             UnityLatestUpdate.onLatestUpdate += _onLateLateUpdate;
 #if UNITY_PHYSICS_3D || UNITY_PHYSICS_2D
             UnityLatestUpdate.onFixedUpdate += _onLateFixedUpdate;
@@ -435,6 +441,8 @@ namespace PurrNet
 
         private void OnDisable()
         {
+            UnityUpdate.onUpdate -= _onUpdate;
+            UnityUpdate.onLateUpdate -= _onLateUpdate;
             UnityLatestUpdate.onLatestUpdate -= _onLateLateUpdate;
 #if UNITY_PHYSICS_3D || UNITY_PHYSICS_2D
             UnityLatestUpdate.onFixedUpdate -= _onLateFixedUpdate;
@@ -941,7 +949,7 @@ namespace PurrNet
         }
 #endif
 
-        private void Update()
+        private void OnUpdate()
         {
             if (_interpolationTiming == InterpolationTiming.Update)
                 UpdateNT();
@@ -954,7 +962,7 @@ namespace PurrNet
             }
         }
 
-        private void LateUpdate()
+        private void OnLateUpdate()
         {
             if (_interpolationTiming == InterpolationTiming.LateUpdate)
                 UpdateNT();

--- a/Assets/PurrNet/Runtime/Utils/UnityUpdate.cs
+++ b/Assets/PurrNet/Runtime/Utils/UnityUpdate.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 namespace PurrNet
 {
     [AddComponentMenu("")]
+    [DefaultExecutionOrder(-1000)]
     public class UnityUpdate : MonoBehaviour
     {
         private static UnityUpdate _instance;

--- a/Assets/PurrNet/Runtime/Utils/UnityUpdate.cs
+++ b/Assets/PurrNet/Runtime/Utils/UnityUpdate.cs
@@ -1,0 +1,42 @@
+using System;
+using UnityEngine;
+
+namespace PurrNet
+{
+    [AddComponentMenu("")]
+    public class UnityUpdate : MonoBehaviour
+    {
+        private static UnityUpdate _instance;
+
+        public static event Action onUpdate;
+        public static event Action onLateUpdate;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void OnSubsystemRegistration()
+        {
+            onUpdate = null;
+            onLateUpdate = null;
+
+            if (_instance)
+                return;
+
+            var go = new GameObject("PurrNet_UnityUpdate")
+            {
+                hideFlags = HideFlags.HideAndDontSave
+            };
+            DontDestroyOnLoad(go);
+
+            _instance = go.AddComponent<UnityUpdate>();
+        }
+
+        private void Update()
+        {
+            onUpdate?.Invoke();
+        }
+
+        private void LateUpdate()
+        {
+            onLateUpdate?.Invoke();
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/Utils/UnityUpdate.cs.meta
+++ b/Assets/PurrNet/Runtime/Utils/UnityUpdate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c4d476beb38498f98ebe3b2ff386949


### PR DESCRIPTION
I made this to reduce the native Unity Update/LateUpdate overhead on NetworkTransform.

With a lot of NetworkTransforms active, having Unity call Update and LateUpdate on every component adds up. I tested this in my game with around 300 active NetworkTransforms and got a pretty noticeable performance improvement by routing them through shared callbacks instead.

I didn’t use UnityLatestUpdate for this because it has DefaultExecutionOrder(32000), so normal Update and LateUpdate would suddenly run very late in the frame. That could change behavior compared to the current setup and also make LateUpdate and LateLateUpdate much closer to the same thing.

So this uses a separate normal-order UnityUpdate dispatcher for Update/LateUpdate, while keeping LateLateUpdate on UnityLatestUpdate as before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790428393&installation_model_id=20441&pr_number=302&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F302&signature=5909463b5eeca9ba4aaba5f0ad84c475da190553c8a3fafc72e575ec5ca6692a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->