### PR TITLE
fix: lower GC from NetworkTransform delegates, add RemoveAt to PurrAction

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
@@ -364,7 +364,11 @@ namespace PurrNet
         private Action _onLateLateUpdate;
 #if UNITY_PHYSICS_3D || UNITY_PHYSICS_2D
         private Action _onLateFixedUpdate;
+        private int _lateFixedUpdateHandle = PurrAction<Action>.InvalidHandle;
 #endif
+        private int _updateHandle = PurrAction<Action>.InvalidHandle;
+        private int _lateUpdateHandle = PurrAction<Action>.InvalidHandle;
+        private int _lateLateUpdateHandle = PurrAction<Action>.InvalidHandle;
 
         private bool _positionTransformExplicit;
         private bool _useAbsoluteFrame;
@@ -415,11 +419,11 @@ namespace PurrNet
         private void OnEnable()
         {
             CacheCurrentPose();
-            UnityUpdate.onUpdate += _onUpdate;
-            UnityUpdate.onLateUpdate += _onLateUpdate;
-            UnityLatestUpdate.onLatestUpdate += _onLateLateUpdate;
+            _updateHandle = UnityUpdate.update.Add(_onUpdate);
+            _lateUpdateHandle = UnityUpdate.lateUpdate.Add(_onLateUpdate);
+            _lateLateUpdateHandle = UnityLatestUpdate.latestUpdate.Add(_onLateLateUpdate);
 #if UNITY_PHYSICS_3D || UNITY_PHYSICS_2D
-            UnityLatestUpdate.onFixedUpdate += _onLateFixedUpdate;
+            _lateFixedUpdateHandle = UnityLatestUpdate.fixedUpdate.Add(_onLateFixedUpdate);
 #endif
 
             if (!_trs)
@@ -441,11 +445,15 @@ namespace PurrNet
 
         private void OnDisable()
         {
-            UnityUpdate.onUpdate -= _onUpdate;
-            UnityUpdate.onLateUpdate -= _onLateUpdate;
-            UnityLatestUpdate.onLatestUpdate -= _onLateLateUpdate;
+            UnityUpdate.update.RemoveAt(_updateHandle, _onUpdate);
+            UnityUpdate.lateUpdate.RemoveAt(_lateUpdateHandle, _onLateUpdate);
+            UnityLatestUpdate.latestUpdate.RemoveAt(_lateLateUpdateHandle, _onLateLateUpdate);
+            _updateHandle = PurrAction<Action>.InvalidHandle;
+            _lateUpdateHandle = PurrAction<Action>.InvalidHandle;
+            _lateLateUpdateHandle = PurrAction<Action>.InvalidHandle;
 #if UNITY_PHYSICS_3D || UNITY_PHYSICS_2D
-            UnityLatestUpdate.onFixedUpdate -= _onLateFixedUpdate;
+            UnityLatestUpdate.fixedUpdate.RemoveAt(_lateFixedUpdateHandle, _onLateFixedUpdate);
+            _lateFixedUpdateHandle = PurrAction<Action>.InvalidHandle;
 #endif
         }
 

--- a/Assets/PurrNet/Runtime/Components/NetworkBones/NetworkBones.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBones/NetworkBones.cs
@@ -1,3 +1,4 @@
+using System;
 using PurrNet.Contributors;
 using PurrNet.Logging;
 using PurrNet.Modules;
@@ -53,6 +54,10 @@ namespace PurrNet
         private float _sendDelta;
         private bool _cachedIsController;
         private bool _cachedConnectedOwner;
+
+        private Action _onLateLateUpdate;
+        private int _lateLateUpdateHandle = PurrAction<Action>.InvalidHandle;
+
         private bool _loggedBoneMismatch;
 
         protected override void OnDestroy()
@@ -106,7 +111,8 @@ namespace PurrNet
 
         private void OnEnable()
         {
-            UnityLatestUpdate.onLatestUpdate += LateLateUpdate;
+            _onLateLateUpdate ??= LateLateUpdate;
+            _lateLateUpdateHandle = UnityLatestUpdate.latestUpdate.Add(_onLateLateUpdate);
 
             if (!isSpawned)
                 return;
@@ -121,7 +127,8 @@ namespace PurrNet
 
         private void OnDisable()
         {
-            UnityLatestUpdate.onLatestUpdate -= LateLateUpdate;
+            UnityLatestUpdate.latestUpdate.RemoveAt(_lateLateUpdateHandle, _onLateLateUpdate);
+            _lateLateUpdateHandle = PurrAction<Action>.InvalidHandle;
         }
 
         private void GatherBones()

--- a/Assets/PurrNet/Runtime/Utils/PurrAction.cs
+++ b/Assets/PurrNet/Runtime/Utils/PurrAction.cs
@@ -7,9 +7,19 @@ namespace PurrNet.Utils
     {
         private const int MinNullsBeforeCompact = 8;
 
+        private static readonly bool UseValueEquality = typeof(Delegate).IsAssignableFrom(typeof(T));
+
+        public const int InvalidHandle = -1;
+
         private T[] _listeners;
+        private int[] _slotToHandle;
+        private int[] _handleToSlot;
+        private int[] _freeHandles;
+
         private int _count;
         private int _nullCount;
+        private int _handleCount;
+        private int _freeHandleCount;
         private int _invokeDepth;
         private readonly Action<T> _invoke;
 
@@ -18,21 +28,65 @@ namespace PurrNet.Utils
         public PurrAction(Action<T> invoke, int capacity = 0)
         {
             _invoke = invoke;
-            _listeners = capacity > 0 ? new T[capacity] : Array.Empty<T>();
+
+            if (capacity > 0)
+            {
+                _listeners = new T[capacity];
+                _slotToHandle = new int[capacity];
+                _handleToSlot = new int[capacity];
+            }
+            else
+            {
+                _listeners = Array.Empty<T>();
+                _slotToHandle = Array.Empty<int>();
+                _handleToSlot = Array.Empty<int>();
+            }
+
+            _freeHandles = Array.Empty<int>();
         }
 
-        public void Add(T listener)
+        public int Add(T listener)
         {
             if (listener == null)
-                return;
+                return InvalidHandle;
 
             if (_invokeDepth == 0 && ShouldCompact())
                 Compact();
 
             if (_count == _listeners.Length)
-                EnsureCapacity();
+                GrowSlots();
 
-            _listeners[_count++] = listener;
+            var handle = RentHandle();
+
+            _listeners[_count] = listener;
+            _slotToHandle[_count] = handle;
+            _handleToSlot[handle] = _count;
+            _count++;
+
+            return handle;
+        }
+
+        /// <summary>
+        /// Removes a listener by the handle <see cref="Add"/> returned. O(1) when the handle
+        /// still points at <paramref name="listener"/>, otherwise falls back to <see cref="Remove"/>.
+        /// </summary>
+        public void RemoveAt(int handle, T listener)
+        {
+            if (listener == null)
+                return;
+
+            if ((uint)handle < (uint)_handleCount)
+            {
+                var slot = _handleToSlot[handle];
+
+                if ((uint)slot < (uint)_count && Matches(_listeners[slot], listener))
+                {
+                    FreeSlot(slot);
+                    return;
+                }
+            }
+
+            Remove(listener);
         }
 
         public void Remove(T listener)
@@ -44,11 +98,23 @@ namespace PurrNet.Utils
 
             for (var i = _count - 1; i >= 0; i--)
             {
-                if (listeners[i] != listener)
+                if (!ReferenceEquals(listeners[i], listener))
                     continue;
 
-                listeners[i] = null;
-                _nullCount++;
+                FreeSlot(i);
+                return;
+            }
+
+            if (!UseValueEquality)
+                return;
+
+            for (var i = _count - 1; i >= 0; i--)
+            {
+                var current = listeners[i];
+                if (current == null || !current.Equals(listener))
+                    continue;
+
+                FreeSlot(i);
                 return;
             }
         }
@@ -69,7 +135,7 @@ namespace PurrNet.Utils
             }
             finally
             {
-                if (--_invokeDepth == 0 && _nullCount > 0)
+                if (--_invokeDepth == 0 && ShouldCompact())
                     Compact();
             }
         }
@@ -85,21 +151,69 @@ namespace PurrNet.Utils
         {
             if (_invokeDepth > 0)
             {
-
                 for (var i = 0; i < _count; i++)
                 {
-                    if (_listeners[i] == null)
-                        continue;
-
-                    _listeners[i] = null;
-                    _nullCount++;
+                    if (_listeners[i] != null)
+                        FreeSlot(i);
                 }
                 return;
+            }
+
+            for (var i = 0; i < _count; i++)
+            {
+                var handle = _slotToHandle[i];
+                if (handle != InvalidHandle)
+                    _handleToSlot[handle] = InvalidHandle;
             }
 
             Array.Clear(_listeners, 0, _count);
             _count = 0;
             _nullCount = 0;
+            _handleCount = 0;
+            _freeHandleCount = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool Matches(T listener, T other)
+        {
+            if (ReferenceEquals(listener, other))
+                return true;
+
+            return UseValueEquality && listener != null && listener.Equals(other);
+        }
+
+        private void FreeSlot(int slot)
+        {
+            var handle = _slotToHandle[slot];
+
+            if (handle != InvalidHandle)
+            {
+                _handleToSlot[handle] = InvalidHandle;
+                ReturnHandle(handle);
+            }
+
+            _listeners[slot] = null;
+            _slotToHandle[slot] = InvalidHandle;
+            _nullCount++;
+        }
+
+        private int RentHandle()
+        {
+            if (_freeHandleCount > 0)
+                return _freeHandles[--_freeHandleCount];
+
+            if (_handleCount == _handleToSlot.Length)
+                Array.Resize(ref _handleToSlot, _handleToSlot.Length == 0 ? 4 : _handleToSlot.Length * 2);
+
+            return _handleCount++;
+        }
+
+        private void ReturnHandle(int handle)
+        {
+            if (_freeHandleCount == _freeHandles.Length)
+                Array.Resize(ref _freeHandles, _freeHandles.Length == 0 ? 4 : _freeHandles.Length * 2);
+
+            _freeHandles[_freeHandleCount++] = handle;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -108,29 +222,32 @@ namespace PurrNet.Utils
             return _nullCount >= MinNullsBeforeCompact && _nullCount * 2 >= _count;
         }
 
-        private void EnsureCapacity()
+        private void GrowSlots()
         {
-            if (_invokeDepth == 0 && _nullCount > 0)
-            {
-                Compact();
-                if (_count < _listeners.Length)
-                    return;
-            }
-
-            Array.Resize(ref _listeners, _listeners.Length == 0 ? 4 : _listeners.Length * 2);
+            var size = _listeners.Length == 0 ? 4 : _listeners.Length * 2;
+            Array.Resize(ref _listeners, size);
+            Array.Resize(ref _slotToHandle, size);
         }
 
         private void Compact()
         {
             var listeners = _listeners;
+            var slotToHandle = _slotToHandle;
             var count = _count;
             var write = 0;
 
             for (var read = 0; read < count; read++)
             {
                 var listener = listeners[read];
-                if (listener != null)
-                    listeners[write++] = listener;
+                if (listener == null)
+                    continue;
+
+                var handle = slotToHandle[read];
+
+                listeners[write] = listener;
+                slotToHandle[write] = handle;
+                _handleToSlot[handle] = write;
+                write++;
             }
 
             Array.Clear(listeners, write, count - write);

--- a/Assets/PurrNet/Runtime/Utils/UnityLatestUpdate.cs
+++ b/Assets/PurrNet/Runtime/Utils/UnityLatestUpdate.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using PurrNet.Pooling;
+using PurrNet.Utils;
 using UnityEngine;
 
 namespace PurrNet
@@ -12,17 +13,44 @@ namespace PurrNet
     {
         static UnityLatestUpdate _instance;
 
-        public static event Action onUpdate;
+        private static readonly PurrAction<Action> _update = new(static action => action(), 32);
+        private static readonly PurrAction<Action> _fixedUpdate = new(static action => action(), 64);
+        private static readonly PurrAction<Action> _latestUpdate = new(static action => action(), 64);
+        private static readonly PurrAction<Action> _postLatestUpdate = new(static action => action(), 8);
 
-        public static event Action onFixedUpdate;
+        public static PurrAction<Action> update => _update;
 
-        public static event Action onLatestUpdate;
+        public static PurrAction<Action> fixedUpdate => _fixedUpdate;
+
+        public static PurrAction<Action> latestUpdate => _latestUpdate;
+
+        public static event Action onUpdate
+        {
+            add => _update.Add(value);
+            remove => _update.Remove(value);
+        }
+
+        public static event Action onFixedUpdate
+        {
+            add => _fixedUpdate.Add(value);
+            remove => _fixedUpdate.Remove(value);
+        }
+
+        public static event Action onLatestUpdate
+        {
+            add => _latestUpdate.Add(value);
+            remove => _latestUpdate.Remove(value);
+        }
 
         /// <summary>
         /// Runs after every <see cref="onLatestUpdate"/> subscriber; for work that must
         /// observe everything the latest-update callbacks produced this frame.
         /// </summary>
-        public static event Action onPostLatestUpdate;
+        public static event Action onPostLatestUpdate
+        {
+            add => _postLatestUpdate.Add(value);
+            remove => _postLatestUpdate.Remove(value);
+        }
 
         private static readonly List<PriorityAction> _executeASAP = new();
 
@@ -139,10 +167,10 @@ namespace PurrNet
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void OnSubsystemRegistration()
         {
-            onUpdate = null;
-            onFixedUpdate = null;
-            onLatestUpdate = null;
-            onPostLatestUpdate = null;
+            _update.Clear();
+            _fixedUpdate.Clear();
+            _latestUpdate.Clear();
+            _postLatestUpdate.Clear();
             lock (_executeASAP)
                 _executeASAP.Clear();
 
@@ -180,7 +208,7 @@ namespace PurrNet
         private void Update()
         {
             TriggerPendingAsaps();
-            onUpdate?.Invoke();
+            _update.Invoke();
 #if UNITY_EDITOR && PURR_LEAKS_CHECK
             _sweep += Time.deltaTime;
 
@@ -195,14 +223,14 @@ namespace PurrNet
         private void FixedUpdate()
         {
             TriggerPendingAsaps();
-            onFixedUpdate?.Invoke();
+            _fixedUpdate.Invoke();
         }
 
         private void LateUpdate()
         {
             TriggerPendingAsaps();
-            onLatestUpdate?.Invoke();
-            onPostLatestUpdate?.Invoke();
+            _latestUpdate.Invoke();
+            _postLatestUpdate.Invoke();
         }
     }
 }

--- a/Assets/PurrNet/Runtime/Utils/UnityUpdate.cs
+++ b/Assets/PurrNet/Runtime/Utils/UnityUpdate.cs
@@ -1,4 +1,5 @@
 using System;
+using PurrNet.Utils;
 using UnityEngine;
 
 namespace PurrNet
@@ -9,14 +10,30 @@ namespace PurrNet
     {
         private static UnityUpdate _instance;
 
-        public static event Action onUpdate;
-        public static event Action onLateUpdate;
+        private static readonly PurrAction<Action> _update = new(static action => action(), 64);
+        private static readonly PurrAction<Action> _lateUpdate = new(static action => action(), 64);
+
+        public static PurrAction<Action> update => _update;
+
+        public static PurrAction<Action> lateUpdate => _lateUpdate;
+
+        public static event Action onUpdate
+        {
+            add => _update.Add(value);
+            remove => _update.Remove(value);
+        }
+
+        public static event Action onLateUpdate
+        {
+            add => _lateUpdate.Add(value);
+            remove => _lateUpdate.Remove(value);
+        }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void OnSubsystemRegistration()
         {
-            onUpdate = null;
-            onLateUpdate = null;
+            _update.Clear();
+            _lateUpdate.Clear();
 
             if (_instance)
                 return;
@@ -32,12 +49,12 @@ namespace PurrNet
 
         private void Update()
         {
-            onUpdate?.Invoke();
+            _update.Invoke();
         }
 
         private void LateUpdate()
         {
-            onLateUpdate?.Invoke();
+            _lateUpdate.Invoke();
         }
     }
 }


### PR DESCRIPTION
Reduced `NetworkTransform`s GC when enabling and disabling it. Previously, we used `Action` callbacks connected through `UnityUpdate.onUpdate += _onUpdate`; now, we have the GC-free `PurrAction` instead.

The CPU benchmark did not show any measurable improvement from switching to `PurrAction` and using a single `Update()`.

However, the results could be significantly different in production builds, especially with the upcoming .NET version.
Here some benchmarks for the new .NET

<img width="643" height="447" alt="image" src="https://github.com/user-attachments/assets/3ccefa57-6335-4fda-873f-9345dc385258" />



Tests with the old system without the single Update loop and with this pullrequest (Editor tests only) :

With new PurrAction
<img width="1920" height="1161" alt="image" src="https://github.com/user-attachments/assets/506f249a-d360-4d2b-afb7-9070f1a1df65" />


With old Update loop 

<img width="1920" height="1161" alt="image" src="https://github.com/user-attachments/assets/b53cf577-cc0d-4bec-8721-3b46962de8fd" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790439045&installation_model_id=20441&pr_number=303&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F303&signature=1e75f123b8fca4ad40aad8a6ed353b4a1592df4e618e76bc38859a9cc72f51a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->