### PR TITLE
fix: addressables, handle ownership and cleanup

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.Addressables.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.Addressables.cs
@@ -19,10 +19,14 @@ namespace PurrNet.Modules
             public AsyncOperationHandle<SceneInstance> handle;
             public SceneID idToAssign;
             public PurrSceneSettings settings;
+            public bool ownsHandle;
         }
 
         private readonly List<PendingAddressableSceneOperation> _pendingAddressableOperations =
             new List<PendingAddressableSceneOperation>();
+
+        private readonly List<AsyncOperationHandle<SceneInstance>> _pendingAddressableUnloads =
+            new List<AsyncOperationHandle<SceneInstance>>();
 
         private readonly Dictionary<SceneID, AsyncOperationHandle<SceneInstance>> _addressableSceneHandles =
             new Dictionary<SceneID, AsyncOperationHandle<SceneInstance>>();
@@ -58,6 +62,9 @@ namespace PurrNet.Modules
 
         partial void ProcessCompletedAddressableLoads()
         {
+            if (_isDisabled)
+                return;
+
             for (var i = _pendingAddressableOperations.Count - 1; i >= 0; i--)
             {
                 var op = _pendingAddressableOperations[i];
@@ -121,7 +128,8 @@ namespace PurrNet.Modules
                 guid = guid,
                 handle = handle,
                 idToAssign = action.sceneID,
-                settings = action.parameters
+                settings = action.parameters,
+                ownsHandle = true
             });
             _sceneActionScenes.Add(action.sceneID);
 
@@ -135,7 +143,8 @@ namespace PurrNet.Modules
                     guid = guid,
                     handle = handle,
                     idToAssign = action.sceneID,
-                    settings = action.parameters
+                    settings = action.parameters,
+                    ownsHandle = false
                 });
                 clientModule._sceneActionScenes.Add(action.sceneID);
                 clientModule.RegisterAddressableCompletionCallback(handle);
@@ -172,6 +181,74 @@ namespace PurrNet.Modules
         private bool TryUnloadAddressableScene(SceneID sceneId, UnloadSceneOptions options)
         {
             return TryRemoveAddressableScene(sceneId, options, false, false, out _);
+        }
+
+        private bool TryUnloadAddressableSceneOnCleanup(SceneID sceneId)
+        {
+            if (!_addressableSceneHandles.TryGetValue(sceneId, out var handle))
+                return false;
+
+            UnregisterAddressableScene(sceneId);
+
+            if (!handle.IsValid())
+                return false;
+
+            _pendingAddressableUnloads.Add(Addressables.UnloadSceneAsync(handle, UnloadSceneOptions.None, true));
+            return true;
+        }
+
+        private bool ArePendingAddressableUnloadsDone()
+        {
+            for (var i = 0; i < _pendingAddressableUnloads.Count; i++)
+            {
+                var handle = _pendingAddressableUnloads[i];
+
+                // The handle releases itself once it completes, which also invalidates it.
+                if (handle.IsValid() && !handle.IsDone)
+                    return false;
+            }
+
+            _pendingAddressableUnloads.Clear();
+            return true;
+        }
+
+        private void ReleasePendingAddressableOperations()
+        {
+            for (var i = 0; i < _pendingAddressableOperations.Count; i++)
+            {
+                var operation = _pendingAddressableOperations[i];
+
+                if (operation.ownsHandle)
+                    ReleaseAddressableSceneHandle(operation.handle);
+            }
+
+            _pendingAddressableOperations.Clear();
+            _pendingAddressableUnloads.Clear();
+        }
+
+        private static void ReleaseAddressableSceneHandle(AsyncOperationHandle<SceneInstance> handle)
+        {
+            if (!handle.IsValid())
+                return;
+
+            if (!handle.IsDone)
+            {
+                // Static callback on purpose: a closure here would keep the discarded module alive.
+                handle.Completed += ReleaseCompletedAddressableSceneHandle;
+                return;
+            }
+
+            ReleaseCompletedAddressableSceneHandle(handle);
+        }
+
+        private static void ReleaseCompletedAddressableSceneHandle(AsyncOperationHandle<SceneInstance> handle)
+        {
+            if (!handle.IsValid())
+                return;
+
+            if (handle.Status == AsyncOperationStatus.Succeeded)
+                Addressables.UnloadSceneAsync(handle, UnloadSceneOptions.None, true);
+            else Addressables.Release(handle);
         }
 
         /// <summary>
@@ -490,7 +567,8 @@ namespace PurrNet.Modules
                 guid = guid,
                 handle = handle,
                 idToAssign = idToAssign,
-                settings = settings
+                settings = settings,
+                ownsHandle = true
             });
 
             RegisterAddressableCompletionCallback(handle);
@@ -503,7 +581,8 @@ namespace PurrNet.Modules
                     guid = guid,
                     handle = handle,
                     idToAssign = idToAssign,
-                    settings = settings
+                    settings = settings,
+                    ownsHandle = false
                 });
                 clientModule._sceneActionScenes.Add(idToAssign);
                 clientModule.RegisterAddressableCompletionCallback(handle);
@@ -571,7 +650,8 @@ namespace PurrNet.Modules
                 guid = guid,
                 handle = handle,
                 idToAssign = idToAssign,
-                settings = settings
+                settings = settings,
+                ownsHandle = true
             });
 
             RegisterAddressableCompletionCallback(handle);
@@ -584,7 +664,8 @@ namespace PurrNet.Modules
                     guid = guid,
                     handle = handle,
                     idToAssign = idToAssign,
-                    settings = settings
+                    settings = settings,
+                    ownsHandle = false
                 });
                 clientModule._sceneActionScenes.Add(idToAssign);
                 clientModule.RegisterAddressableCompletionCallback(handle);

--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.Addressables.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.Addressables.cs
@@ -212,9 +212,9 @@ namespace PurrNet.Modules
             return true;
         }
 
-        private void ReleasePendingAddressableOperations()
+        private void DiscardPendingAddressableOperations(bool unloadPendingScenes)
         {
-            for (var i = 0; i < _pendingAddressableOperations.Count; i++)
+            for (var i = 0; unloadPendingScenes && i < _pendingAddressableOperations.Count; i++)
             {
                 var operation = _pendingAddressableOperations[i];
 

--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
@@ -445,7 +445,12 @@ namespace PurrNet.Modules
 #if ADDRESSABLES_PURRNET_SUPPORT
             // This module is about to be discarded; any addressable load still in flight would
             // otherwise complete into a registry nobody owns and never be unloaded by anyone.
-            ReleasePendingAddressableOperations();
+            // Unless the rules keep scenes around on disconnect: dropping a scene that just happened
+            // to still be loading, while every scene that finished in time is kept, is worse.
+            var sceneRules = _networkManager.networkRules;
+            var unloadPendingScenes = !sceneRules || sceneRules.ShouldCleanupScenesOnDisconnect();
+
+            DiscardPendingAddressableOperations(unloadPendingScenes);
 #endif
 
             if (!asServer)

--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
@@ -235,6 +235,7 @@ namespace PurrNet.Modules
         }
 
         private bool _wasSetup;
+        private bool _isDisabled;
 
         static GameObject _dontDestroyOnLoad;
 
@@ -434,10 +435,19 @@ namespace PurrNet.Modules
         public void Enable(bool asServer)
         {
             // Setup(asServer);
+            _isDisabled = false;
         }
 
         public void Disable(bool asServer)
         {
+            _isDisabled = true;
+
+#if ADDRESSABLES_PURRNET_SUPPORT
+            // This module is about to be discarded; any addressable load still in flight would
+            // otherwise complete into a registry nobody owns and never be unloaded by anyone.
+            ReleasePendingAddressableOperations();
+#endif
+
             if (!asServer)
             {
                 _players.Unsubscribe<SceneActionsBatch>(OnSceneActionsBatch);
@@ -1440,6 +1450,16 @@ namespace PurrNet.Modules
             if (_pendingOperations.Count > 0)
                 return false;
 
+#if ADDRESSABLES_PURRNET_SUPPORT
+            // Addressable loads are driven by their completion callback, but FixedUpdate no longer
+            // runs while disconnecting, so drain them here as well. They need to land in _scenes
+            // before UnloadAllScenesCleanup runs, otherwise nothing would ever unload them.
+            ProcessCompletedAddressableLoads();
+
+            if (_pendingAddressableOperations.Count > 0)
+                return false;
+#endif
+
             switch (_cleanupStage)
             {
                 case CleanupStage.None:
@@ -1576,7 +1596,7 @@ namespace PurrNet.Modules
             {
                 _pendingUnloads.Clear();
 
-                foreach (var (_, scene) in _scenes)
+                foreach (var (id, scene) in _scenes)
                 {
                     var unityScene = scene.scene;
 
@@ -1592,6 +1612,13 @@ namespace PurrNet.Modules
                     if (IsDontDestroyOnLoadScene(unityScene))
                         continue;
 
+#if ADDRESSABLES_PURRNET_SUPPORT
+                    // Addressable scenes must go through Addressables so the handle is released
+                    // as well, instead of leaking next to an unloaded scene.
+                    if (TryUnloadAddressableSceneOnCleanup(id))
+                        continue;
+#endif
+
                     _pendingUnloads.Add(SceneManager.UnloadSceneAsync(unityScene));
                 }
 
@@ -1606,6 +1633,11 @@ namespace PurrNet.Modules
                         return false;
                 }
             }
+
+#if ADDRESSABLES_PURRNET_SUPPORT
+            if (!ArePendingAddressableUnloadsDone())
+                return false;
+#endif
 
             return true;
         }


### PR DESCRIPTION
Add ownership tracking and proper cleanup for Addressables scenes. Introduces ownsHandle on pending ops and scene-handle entries, tracks pending unload handles, and adds ReleasePendingAddressableOperations, ReleaseAddressableSceneHandle (with completion callback), TryUnloadAddressableSceneOnCleanup, and ArePendingAddressableUnloadsDone. Prevents leaks by draining/completing addressable loads during Disable/cleanup (guarded by _isDisabled) and uses Addressables API to unload handles. Also fixes scene iteration to expose the scene id in cleanup. All addressable logic is wrapped in ADDRESSABLES_PURRNET_SUPPORT blocks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790965781&installation_model_id=20441&pr_number=306&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F306&signature=b399488e373eb74c3f979ac411a59223305b621b6bc196d5546cdaace65e8056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->