### PR TITLE
perf: remove the two per-spawn allocations on the Instantiate path

### DIFF
--- a/Assets/PurrNet/Codegen/PostProcessor.cs
+++ b/Assets/PurrNet/Codegen/PostProcessor.cs
@@ -4908,6 +4908,57 @@ namespace PurrNet.Codegen
             }
 
             code.Append(Instruction.Create(OpCodes.Ret));
+
+            if (isNetworkIdentity && type.FullName != typeof(NetworkIdentity).FullName)
+                CreateInitDispatchOverride(module, type, newMethod);
+        }
+
+        private static void CreateInitDispatchOverride(ModuleDefinition module, TypeDefinition type,
+            MethodDefinition initMethod)
+        {
+            const string DISPATCH_NAME = "CallGeneratedInitMethods";
+
+            var dispatch = new MethodDefinition(DISPATCH_NAME,
+                MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.Virtual |
+                MethodAttributes.ReuseSlot, module.TypeSystem.Void)
+            {
+                HasThis = true
+            };
+
+            type.Methods.Add(dispatch);
+
+            var body = dispatch.Body.GetILProcessor();
+
+            if (type.BaseType != null)
+            {
+                var baseRef = new MethodReference(DISPATCH_NAME, module.TypeSystem.Void, type.BaseType.Import(module))
+                {
+                    HasThis = true
+                };
+
+                body.Append(Instruction.Create(OpCodes.Ldarg_0));
+                body.Append(Instruction.Create(OpCodes.Call, baseRef));
+
+                dispatch.Overrides.Add(baseRef);
+            }
+
+            MethodReference selfInit = initMethod;
+
+            if (type.HasGenericParameters)
+            {
+                var git = new GenericInstanceType(type);
+                foreach (var gp in type.GenericParameters)
+                    git.GenericArguments.Add(gp);
+
+                selfInit = new MethodReference(initMethod.Name, module.TypeSystem.Void, git)
+                {
+                    HasThis = true
+                };
+            }
+
+            body.Append(Instruction.Create(OpCodes.Ldarg_0));
+            body.Append(Instruction.Create(OpCodes.Call, selfInit));
+            body.Append(Instruction.Create(OpCodes.Ret));
         }
 
         private static void FindUsedTypes(ModuleDefinition module, DisposableList<TypeDefinition> allTypes,

--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using JetBrains.Annotations;
 using PurrNet.Logging;
 using PurrNet.Modules;
@@ -905,30 +904,8 @@ namespace PurrNet
         {
         }
 
-        static readonly Dictionary<Type, List<MethodInfo>> _methodCache = new();
-
-        private void CallInitMethods()
-        {
-            if (!_methodCache.TryGetValue(GetType(), out var cached))
-            {
-                var type = GetType();
-                var methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public);
-                cached = new List<MethodInfo>(methods.Length);
-
-                for (int i = 0; i < methods.Length; i++)
-                {
-                    var m = methods[i];
-                    if (m.Name.EndsWith("_CodeGen_Initialize"))
-                        cached.Add(m);
-                }
-
-                _methodCache[type] = cached;
-            }
-
-            int count = cached.Count;
-            for (var i = 0; i < count; i++)
-                cached[i].Invoke(this, Array.Empty<object>());
-        }
+        [UsedByIL, UsedImplicitly]
+        public virtual void CallGeneratedInitMethods() { }
 
         /// <summary>
         /// The layer of this object. Avoids gameObject.layer.
@@ -1059,7 +1036,7 @@ namespace PurrNet
                 _moduleId = 0;
 
                 OnInitializeModules();
-                CallInitMethods();
+                CallGeneratedInitMethods();
 
                 foreach (var module in _externalModulesView)
                     module.OnInitializeModules();

--- a/Assets/PurrNet/Runtime/Components/NetworkPrefabs/NetworkPrefabs.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkPrefabs/NetworkPrefabs.cs
@@ -39,6 +39,7 @@ namespace PurrNet
         public int count => prefabLookup.Count;
 
         private readonly Dictionary<int, PrefabData> prefabLookup = new();
+        private readonly Dictionary<GameObject, PrefabData> prefabToData = new();
         private readonly Dictionary<string, PrefabData> persistentIdToPrefabData = new();
         private readonly Dictionary<int, string> prefabIdToPersistentId = new();
         private readonly Dictionary<GameObject, string> prefabToPersistentId = new();
@@ -50,14 +51,8 @@ namespace PurrNet
 
         public override bool TryGetPrefabData(GameObject prefab, out PrefabData prefabData)
         {
-            foreach (var data in this.allPrefabs)
-            {
-                if (data.prefab == prefab)
-                {
-                    prefabData = data;
-                    return true;
-                }
-            }
+            if (prefab)
+                return prefabToData.TryGetValue(prefab, out prefabData);
 
             prefabData = default;
             return false;
@@ -151,6 +146,7 @@ namespace PurrNet
         private void RegeneratePrefabLookup()
         {
             prefabLookup.Clear();
+            prefabToData.Clear();
             persistentIdToPrefabData.Clear();
             prefabIdToPersistentId.Clear();
             prefabToPersistentId.Clear();
@@ -174,6 +170,10 @@ namespace PurrNet
                 };
 
                 prefabLookup.Add(i, data);
+
+                if (!prefabToData.ContainsKey(ud.prefab))
+                    prefabToData.Add(ud.prefab, data);
+
                 RegisterPersistentId(ud.guid, data);
             }
 


### PR DESCRIPTION
Both allocations below happen on **every** `UnityProxy.Instantiate` of a network prefab, pooled or not — a pooled prefab skips the real `Object.Instantiate` but still goes through `TryGetPrefabData` and `NotifyGameObjectCreated -> SetIdentity -> CallInitMethods`. Found while profiling a 2D MMO server where AI casters spawn projectiles continuously; every monster auto-attack allocated on the server.

## 1. `NetworkPrefabs.TryGetPrefabData(GameObject)` — 64 B + a full scan per spawn

```
KeyCollection.GetEnumerator()                    <- 64 B
PurrNet.NetworkPrefabs.TryGetPrefabData()
PurrNet.PrefabResolver.TryGetPrefabData()
PurrNet.UnityProxy.TryGetPrefabData()
PurrNet.UnityProxy.Instantiate()
```

The method walked `allPrefabs` comparing `data.prefab == prefab`. Two costs:

* `allPrefabs` is typed `IEnumerable<PrefabData>`, so the `Dictionary.ValueCollection` enumerator is boxed once per spawn.
* It is O(registered prefabs) with a `UnityEngine.Object` comparison per element. In our project that is ~1.6k comparisons per projectile.

Fixed with a `Dictionary<GameObject, PrefabData>` filled in `RegeneratePrefabLookup`, the single funnel used by both `OnEnable` and `Refresh`. First registration wins, which is what the first-match scan did, and both forms compare by reference, so results are identical.

`CompositePrefabProvider` already memoizes this in `_prefabCache`, so the scan only showed up when a plain `NetworkPrefabs` asset is the provider (i.e. any project not using `AddressableNetworkPrefabs`). `AddressableNetworkPrefabs` has the same scan but is always reached through the composite's cache, and its `_prefabLookup` is mutated as bundles load, so I left it alone rather than adding a reverse map that has to be invalidated in five places.

## 2. `NetworkIdentity.CallInitMethods` — 32 B per identity per spawn

```
System.Reflection.RuntimeMethodInfo.Invoke()     <- 32 B
System.Reflection.MethodBase.Invoke()
PurrNet.NetworkIdentity.CallInitMethods()
PurrNet.NetworkIdentity.SetIdentity()
PurrNet.Modules.HierarchyV2.SetupIdsLocally()
```

The `MethodInfo`s were cached per type, but `MethodInfo.Invoke` still allocates per call even with `Array.Empty<object>()` — and it is runtime reflection on the spawn path, which IL2CPP builds would rather not have at all.

`NetworkIdentity` now declares:

```csharp
[UsedByIL, UsedImplicitly]
public virtual void CallGeneratedInitMethods() { }
```

and `CreateSyncVarInitMethod` emits an override on every weaved identity type:

```csharp
public override void CallGeneratedInitMethods()
{
    base.CallGeneratedInitMethods();
    __MyBehaviour_CodeGen_Initialize();
}
```

This is the same chaining `HandleRPCReceiverHandler` already generates for `OnReceivedRpc` (virtual + `ReuseSlot` + `Overrides.Add` on the base reference), and the same base-first order the `NetworkModule` initializers already chain in. Generic types reference their own initializer through a `GenericInstanceType`, matching the field references in the same method.

`NetworkIdentity` itself is excluded from the override (it declares the virtual, and it owns no `NetworkModule` fields, so its generated initializer is an empty `ret`). Types that get no override — a base class the weaver skipped, or a precompiled assembly — still work, because the virtual call resolves to the nearest ancestor that does override, which is what the reflection scan effectively did.

### One behavioural note

Registration order is now deterministic and base-first. It used to be whatever order `Type.GetMethods` returned, which is unspecified — and since `RegisterModuleInternal` assigns module ids by increment, that order decides module ids on the wire. In practice this means:

* Peers on different builds of this change are not wire compatible with peers on older builds (fine for a beta bump).
* It removes a latent risk: a Mono editor host and an IL2CPP client could disagree on `GetMethods` order today.

## Testing

* Both changes parse and compile clean in isolation (Roslyn reports only the expected missing-reference errors when the files are compiled without the project's assemblies).
* The prefab-lookup change is behaviour-preserving by construction and is what I would merge first.
* **The codegen change needs a weave run on CI / a real project before merge** — I mirrored the existing `OnReceivedRpc` emitter closely, but I could not run the ILPostProcessor here. A good smoke test is any prefab with a base `NetworkBehaviour` that also declares SyncVars, plus one generic `NetworkBehaviour<T>`.



Before:

<img width="1920" height="1165" alt="image" src="https://github.com/user-attachments/assets/d2f22b89-a916-4b61-adf7-d21dae5c2cd3" />



<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791499126&installation_model_id=20441&pr_number=308&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F308&signature=b30a50036b566e401c66555df891750b54b50f11a7f9b6bbe0bbedb3288bfd99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
