### PR TITLE
perf: reuse interpolation buffers across respawns

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
@@ -319,6 +319,13 @@ namespace PurrNet
         Interpolated<QuaternionWithParent> _rotation;
         Interpolated<ScaleWithParent> _scale;
 
+        static readonly LerpFunction<Vector3WithParent> _positionLerp = Vector3WithParent.Lerp;
+        static readonly LerpFunction<Vector3WithParent> _positionNoLerp = Vector3WithParent.NoLerp;
+        static readonly LerpFunction<QuaternionWithParent> _rotationLerp = QuaternionWithParent.Lerp;
+        static readonly LerpFunction<QuaternionWithParent> _rotationNoLerp = QuaternionWithParent.NoLerp;
+        static readonly LerpFunction<ScaleWithParent> _scaleLerp = ScaleWithParent.Lerp;
+        static readonly LerpFunction<ScaleWithParent> _scaleNoLerp = ScaleWithParent.NoLerp;
+
         public Vector3 latestReadPosition
         {
             get
@@ -475,8 +482,11 @@ namespace PurrNet
             if (syncPosition)
             {
                 var currentPos = MakePositionSample(p, data);
-                _position = new Interpolated<Vector3WithParent>(interpolatePosition ? Vector3WithParent.Lerp : Vector3WithParent.NoLerp,
-                    sendDelta, currentPos, _maxBufferSize, _minBufferSize);
+                var lerp = interpolatePosition ? _positionLerp : _positionNoLerp;
+
+                if (_position == null)
+                    _position = new Interpolated<Vector3WithParent>(lerp, sendDelta, currentPos, _maxBufferSize, _minBufferSize);
+                else _position.Reset(lerp, sendDelta, currentPos, _maxBufferSize, _minBufferSize);
             }
 
             if (syncRotation)
@@ -484,16 +494,21 @@ namespace PurrNet
                 var currentRot = _syncRotation == SyncMode.World ?
                     new QuaternionWithParent(p, false, _trs.rotation) :
                     new QuaternionWithParent(p, true, _trs.localRotation);
-                _rotation = new Interpolated<QuaternionWithParent>(
-                    interpolateRotation ? QuaternionWithParent.Lerp : QuaternionWithParent.NoLerp,
-                    sendDelta, currentRot, _maxBufferSize, _minBufferSize);
+                var lerp = interpolateRotation ? _rotationLerp : _rotationNoLerp;
+
+                if (_rotation == null)
+                    _rotation = new Interpolated<QuaternionWithParent>(lerp, sendDelta, currentRot, _maxBufferSize, _minBufferSize);
+                else _rotation.Reset(lerp, sendDelta, currentRot, _maxBufferSize, _minBufferSize);
             }
 
             if (syncScale)
             {
                 var currentScale = new ScaleWithParent(p, _trs.localScale);
-                _scale = new Interpolated<ScaleWithParent>(interpolateScale ? ScaleWithParent.Lerp : ScaleWithParent.NoLerp,
-                    sendDelta, currentScale, _maxBufferSize, _minBufferSize);
+                var lerp = interpolateScale ? _scaleLerp : _scaleNoLerp;
+
+                if (_scale == null)
+                    _scale = new Interpolated<ScaleWithParent>(lerp, sendDelta, currentScale, _maxBufferSize, _minBufferSize);
+                else _scale.Reset(lerp, sendDelta, currentScale, _maxBufferSize, _minBufferSize);
             }
 
             _currentData = data;

--- a/Assets/PurrNet/Runtime/Interpolation/Interpolated.cs
+++ b/Assets/PurrNet/Runtime/Interpolation/Interpolated.cs
@@ -8,7 +8,7 @@ namespace PurrNet
     [DontPack]
     public class Interpolated<T>
     {
-        private readonly LerpFunction<T> _lerp;
+        private LerpFunction<T> _lerp;
         private readonly List<T> _buffer;
         private T _lastValue;
         private T _currentStateRaw;
@@ -48,6 +48,28 @@ namespace PurrNet
 
             _tickDelta = tickDelta;
             _lastValue = initialValue;
+            _waitForMinBufferSize = true;
+        }
+
+        public void Reset(LerpFunction<T> lerp, float tickDelta, T initialValue = default, int maxBufferSize = 2, int minBufferSize = 1)
+        {
+            _lerp = lerp ?? throw new ArgumentNullException(nameof(lerp));
+
+            if (tickDelta <= 0f)
+                throw new ArgumentException("tickDelta must be greater than 0", nameof(tickDelta));
+
+            if (_buffer.Capacity < maxBufferSize)
+                _buffer.Capacity = maxBufferSize;
+            _buffer.Clear();
+
+            this.maxBufferSize = maxBufferSize;
+            this.minBufferSize = minBufferSize;
+
+            _tickDelta = tickDelta;
+            _lastValue = initialValue;
+            _currentStateRaw = default;
+            _timer = 0f;
+            _idleTime = 0f;
             _waitForMinBufferSize = true;
         }
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791555725&installation_model_id=20441&pr_number=309&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F309&signature=d3123fc0285759d5cfc6ba54a4b18f6908fad5e019ee6147ce2bbe1eeb430db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->