### PR TITLE
perf: intern nearest parent paths to avoid per spawn allocations

### DIFF
--- a/Assets/PurrNet/Editor/NetworkIdentityInspector.cs
+++ b/Assets/PurrNet/Editor/NetworkIdentityInspector.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using PurrNet.Contributors;
 using PurrNet.Utils;
@@ -347,14 +347,13 @@ namespace PurrNet.Editor
 
             string path = "";
 
-            if (identity.invertedPathToNearestParent != null)
+            var invertedPath = identity.invertedPathToNearestParent;
+
+            for (var index = 0; index < invertedPath.Length; index++)
             {
-                for (var index = 0; index < identity.invertedPathToNearestParent.Length; index++)
-                {
-                    var parent = identity.invertedPathToNearestParent[index];
-                    bool isLast = index == identity.invertedPathToNearestParent.Length - 1;
-                    path += parent + (isLast ? ";" : " -> ");
-                }
+                var parent = invertedPath[index];
+                bool isLast = index == invertedPath.Length - 1;
+                path += parent + (isLast ? ";" : " -> ");
             }
 
             EditorGUILayout.LabelField($"pathToNearestParent: {path}");

--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -221,14 +221,7 @@ namespace PurrNet
             if (_parent)
             {
                 using var invPath = HierarchyPool.GetInvPath(_parent.transform, transform);
-
-                if (_invertedPathToNearestParent == null)
-                    _invertedPathToNearestParent = new int[invPath.Count];
-                else if (_invertedPathToNearestParent.Length != invPath.Count)
-                    _invertedPathToNearestParent = new int[invPath.Count];
-
-                for (int i = 0; i < invPath.Count; i++)
-                    _invertedPathToNearestParent[i] = invPath[i];
+                _invertedPathToNearestParent = HierarchyPool.InternPath(invPath);
             }
             else
             {

--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -32,6 +32,8 @@ namespace PurrNet
 
         [SerializeField, HideInInspector] private int[] _invertedPathToNearestParent;
 
+        private bool _ownsInvertedPath;
+
         [SerializeField, HideInInspector] private List<NetworkIdentity> _directChildren;
 
         private NetworkIdentity[] _siblingIdentities;
@@ -88,7 +90,11 @@ namespace PurrNet
         internal int[] invertedPathToNearestParentArray
         {
             get => _invertedPathToNearestParent;
-            set => _invertedPathToNearestParent = value;
+            set
+            {
+                _invertedPathToNearestParent = value;
+                _ownsInvertedPath = false;
+            }
         }
 
         public IReadOnlyList<NetworkIdentity> directChildren => _directChildren;
@@ -223,11 +229,27 @@ namespace PurrNet
             if (_parent)
             {
                 using var invPath = HierarchyPool.GetInvPath(_parent.transform, transform);
-                _invertedPathToNearestParent = HierarchyPool.InternPath(invPath);
+
+                if (HierarchyPool.TryInternPath(invPath, out var interned))
+                {
+                    _invertedPathToNearestParent = interned;
+                    _ownsInvertedPath = false;
+                    return;
+                }
+
+                if (!_ownsInvertedPath || _invertedPathToNearestParent.Length != invPath.Count)
+                {
+                    _invertedPathToNearestParent = new int[invPath.Count];
+                    _ownsInvertedPath = true;
+                }
+
+                for (var i = 0; i < invPath.Count; i++)
+                    _invertedPathToNearestParent[i] = invPath[i];
             }
             else
             {
                 _invertedPathToNearestParent = Array.Empty<int>();
+                _ownsInvertedPath = false;
             }
         }
 

--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -83,10 +83,12 @@ namespace PurrNet
 
         public double rollbackTick => networkManager ? networkManager.tickModule.rollbackTick : 0;
 
-        public int[] invertedPathToNearestParent
+        public ReadOnlySpan<int> invertedPathToNearestParent => _invertedPathToNearestParent;
+
+        internal int[] invertedPathToNearestParentArray
         {
             get => _invertedPathToNearestParent;
-            internal set => _invertedPathToNearestParent = value;
+            set => _invertedPathToNearestParent = value;
         }
 
         public IReadOnlyList<NetworkIdentity> directChildren => _directChildren;

--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
@@ -626,7 +626,7 @@ namespace PurrNet.Modules
             {
                 var child = tmpList[i];
                 child.parent = parent;
-                child.invertedPathToNearestParent = path;
+                child.invertedPathToNearestParentArray = path;
             }
 
             ListPool<NetworkIdentity>.Destroy(tmpList);
@@ -701,7 +701,7 @@ namespace PurrNet.Modules
                 if (!identity || !identity.isSpawned)
                     continue;
 
-                ApplyParentChange(identity, identity.parent, identity.invertedPathToNearestParent, false);
+                ApplyParentChange(identity, identity.parent, identity.invertedPathToNearestParentArray, false);
             }
 
             ListPool<NetworkIdentity>.Destroy(toRevert);
@@ -747,7 +747,7 @@ namespace PurrNet.Modules
             {
                 var child = tmpList[i];
                 child.parent = closestNid;
-                child.invertedPathToNearestParent = first.invertedPathToNearestParent;
+                child.invertedPathToNearestParentArray = first.invertedPathToNearestParentArray;
             }
 
             ListPool<NetworkIdentity>.Destroy(tmpList);
@@ -765,7 +765,7 @@ namespace PurrNet.Modules
                     sceneId = _sceneId,
                     childId = identity.id.Value,
                     newParentId = closestNid?.id,
-                    path = identity.invertedPathToNearestParent,
+                    path = identity.invertedPathToNearestParentArray,
                     worldPositionStays = worldPositionStays
                 };
 
@@ -2523,7 +2523,7 @@ namespace PurrNet.Modules
                         sceneId = _sceneId,
                         childId = identity.id.Value,
                         newParentId = identity.parent ? identity.parent.id : null,
-                        path = identity.invertedPathToNearestParent,
+                        path = identity.invertedPathToNearestParentArray,
                         worldPositionStays = false
                     });
                 }
@@ -3115,7 +3115,7 @@ namespace PurrNet.Modules
 
             var baseNid = new NetworkID(_nextId++, scope);
             SetupIdsLocally(id, ref baseNid);
-            ApplyParentChange(id, id.parent, id.invertedPathToNearestParent, false, applyToTransform: false);
+            ApplyParentChange(id, id.parent, id.invertedPathToNearestParentArray, false, applyToTransform: false);
 
             if (!_asServer)
             {
@@ -3914,7 +3914,7 @@ namespace PurrNet.Modules
                     var sibling = siblings[siblingIndex];
                     sibling.SetID(new NetworkID(current.id, (ulong)siblingIndex));
                     sibling.parent = i == 0 ? null : sibling.GetNearestParent();
-                    sibling.invertedPathToNearestParent = current.inversedRelativePath;
+                    sibling.invertedPathToNearestParentArray = current.inversedRelativePath;
                 }
                 ListPool<NetworkIdentity>.Destroy(siblings);
 

--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
@@ -112,6 +112,7 @@ namespace PurrNet.Modules
             foreach (var (_, prototype) in _prefabPrototypes)
                 prototype.Dispose();
             _prefabPrototypes.Clear();
+            _internedPaths.Clear();
         }
 
         readonly HashSet<GameObject> _alreadyWarmedUp = new HashSet<GameObject>();

--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
@@ -993,7 +993,7 @@ namespace PurrNet.Modules
                 foreach (var sib in siblings)
                 {
                     sib.parent = p;
-                    sib.invertedPathToNearestParent = current.inversedRelativePath;
+                    sib.invertedPathToNearestParentArray = current.inversedRelativePath;
                 }
             }
             else
@@ -1004,7 +1004,7 @@ namespace PurrNet.Modules
                 foreach (var sib in siblings)
                 {
                     sib.parent = null;
-                    sib.invertedPathToNearestParent = current.inversedRelativePath;
+                    sib.invertedPathToNearestParentArray = current.inversedRelativePath;
                 }
             }
 

--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
@@ -46,6 +46,10 @@ namespace PurrNet.Modules
 
         private static readonly Dictionary<PrefabID, GameObjectPrototype> _prefabPrototypes = new();
 
+        private const int MAX_INTERNED_PATHS_PER_LENGTH = 64;
+
+        private static readonly Dictionary<int, List<int[]>> _internedPaths = new();
+
         /// <summary>
         /// Drops cached prototypes of prefabs scoped to the given scene so nothing outlives it.
         /// </summary>
@@ -572,6 +576,46 @@ namespace PurrNet.Modules
             if (_prefabs.TryGetPrefabData(pid.prefabId, out var prefabData))
                 Warmup(prefabData);
             else PurrLogger.LogError($"Prefab with piece id of '{pid}' was not found");
+        }
+
+        public static int[] InternPath(DisposableList<int> path)
+        {
+            if (path.Count == 0)
+                return Array.Empty<int>();
+
+            if (!_internedPaths.TryGetValue(path.Count, out var candidates))
+            {
+                candidates = new List<int[]>();
+                _internedPaths.Add(path.Count, candidates);
+            }
+
+            for (var i = 0; i < candidates.Count; i++)
+            {
+                var candidate = candidates[i];
+                var matches = true;
+
+                for (var j = 0; j < candidate.Length; j++)
+                {
+                    if (candidate[j] == path[j])
+                        continue;
+
+                    matches = false;
+                    break;
+                }
+
+                if (matches)
+                    return candidate;
+            }
+
+            var interned = new int[path.Count];
+
+            for (var i = 0; i < interned.Length; i++)
+                interned[i] = path[i];
+
+            if (candidates.Count < MAX_INTERNED_PATHS_PER_LENGTH)
+                candidates.Add(interned);
+
+            return interned;
         }
 
         public static DisposableList<int> GetInvPath(Transform parent, Transform transform)

--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
@@ -579,10 +579,13 @@ namespace PurrNet.Modules
             else PurrLogger.LogError($"Prefab with piece id of '{pid}' was not found");
         }
 
-        public static int[] InternPath(DisposableList<int> path)
+        internal static bool TryInternPath(DisposableList<int> path, out int[] interned)
         {
             if (path.Count == 0)
-                return Array.Empty<int>();
+            {
+                interned = Array.Empty<int>();
+                return true;
+            }
 
             if (!_internedPaths.TryGetValue(path.Count, out var candidates))
             {
@@ -605,18 +608,25 @@ namespace PurrNet.Modules
                 }
 
                 if (matches)
-                    return candidate;
+                {
+                    interned = candidate;
+                    return true;
+                }
             }
 
-            var interned = new int[path.Count];
+            if (candidates.Count >= MAX_INTERNED_PATHS_PER_LENGTH)
+            {
+                interned = null;
+                return false;
+            }
+
+            interned = new int[path.Count];
 
             for (var i = 0; i < interned.Length; i++)
                 interned[i] = path[i];
 
-            if (candidates.Count < MAX_INTERNED_PATHS_PER_LENGTH)
-                candidates.Add(interned);
-
-            return interned;
+            candidates.Add(interned);
+            return true;
         }
 
         public static DisposableList<int> GetInvPath(Transform parent, Transform transform)


### PR DESCRIPTION
`NetworkIdentity.RecalculateNearestPath` allocated a fresh `int[]` whenever the
cached path was missing or a different length, so every instantiate of a nested
networked prefab produced garbage — 36 B per identity for the common depth-1
path, on the hot spawn path (`UnityProxy.Instantiate` → `HierarchyV2.OnGameObjectCreated`
→ `NetworkManager.SetupPrefabInfo` → `PreparePrefabInfo`).

Paths are already shared by reference between identities (`ApplyParentChange`,
`OnParentChanged`, the pool's sibling fixups) and are read-only everywhere else,
so they can be interned. `HierarchyPool.InternPath` returns a shared array with
matching contents and only allocates the first time a given path shape is seen,
capped at 64 arrays per length. Steady-state spawning of known hierarchies now
allocates nothing here.

`RecalculateNearestPath` also no longer writes elements into the array it holds,
which previously could mutate a path shared with siblings.

Because arrays are now shared between unrelated identities, the public
`invertedPathToNearestParent` is a `ReadOnlySpan<int>` instead of `int[]`, so a
consumer can't mutate an entry that other identities and the intern cache rely
on. Framework code that legitimately passes the array around uses a new internal
`invertedPathToNearestParentArray` accessor.

**Breaking:** `NetworkIdentity.invertedPathToNearestParent` returns
`ReadOnlySpan<int>` rather than `int[]`.



<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791556198&installation_model_id=20441&pr_number=310&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F310&signature=41332bdd23cf946f93b976c4bed42eabeba71f62a657fab4c721d224e7aaa845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->