### PR TITLE
perf: avoid boxed enumerator when despawning pooled hierarchies

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs
@@ -230,7 +230,8 @@ namespace PurrNet.Modules
             QueueVirtualNodesFromLeafToRoot(root, virtualNodes);
             QueueRealNodesFromLeafToRoot(root, realNodes);
 
-            realNodes.ExceptWith(virtualNodes);
+            foreach (var virtualNode in virtualNodes)
+                realNodes.Remove(virtualNode);
 
             // save the objects that should not be despawned
             foreach (var real in realNodes)


### PR DESCRIPTION

<img width="1217" height="395" alt="image" src="https://github.com/user-attachments/assets/800466e3-852d-41e8-8dd1-862568bb8d2c" />


```C#
GC.Alloc
0,007ms

Current frame accumulated time:
0,822ms for 121 instances on thread 'Main Thread'
Size: 40
Call Stack:
System.Core.dll!System.Collections.Generic::HashSet`1.System.Collections.IEnumerable.GetEnumerator()	<a href="<no-source>" line="1"><no-source>:1</a>
System.Core.dll!System.Collections.Generic::HashSet`1.ExceptWith()	<a href="<no-source>" line="1"><no-source>:1</a>
PurrNet.Runtime.dll!PurrNet.Modules::HierarchyPool.PutBackInPoolFromNid()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs" line="225">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs:225</a>
PurrNet.Runtime.dll!PurrNet.Modules::HierarchyPool.PutBackInPool()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs" line="163">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/Pool/HierarchyPool.cs:163</a>
PurrNet.Runtime.dll!PurrNet.Modules::HierarchyV2.Despawn()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs" line="3219">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:3219</a>
PurrNet.Runtime.dll!PurrNet::NetworkIdentity.Despawn()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Components/NetworkIdentity/NetworkIdentity.cs" line="911">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Components/NetworkIdentity/NetworkIdentity.cs:911</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.OnDestroy()	<a href="<no-source>" line="1"><no-source>:1</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.Destroy()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs" line="613">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs:613</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::Projectile.End()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Projectile.cs" line="1224">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Projectile.cs:1224</a>
Assembly-CSharp.dll!::<EndAfterLifetime>d__81.MoveNext()	<a href="<no-source>" line="1"><no-source>:1</a>
UniTask.dll!Cysharp.Threading.Tasks::UniTaskCompletionSourceCore`1.TrySetResult()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTaskCompletionSource.cs" line="125">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTaskCompletionSource.cs:125</a>
UniTask.dll!::DelayPromise.MoveNext()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTask.Delay.cs" line="789">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTask.Delay.cs:789</a>
UniTask.dll!Cysharp.Threading.Tasks.Internal::PlayerLoopRunner.RunCore()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/Internal/PlayerLoopRunner.cs" line="153">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/Internal/PlayerLoopRunner.cs:153</a>

```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791561554&installation_model_id=20441&pr_number=311&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F311&signature=12854e63e1d0e9fb156a5fb6d20ab5dc22f47dd78bf311c9ebd8c42628161fe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->