### PR TITLE
perf: avoid boxed enumerator when clearing observers

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/VisilityV2.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/VisilityV2.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using PurrNet.Pooling;
 using Unity.Profiling;
 using UnityEngine;
@@ -216,14 +216,20 @@ namespace PurrNet.Modules
                 }
                 else
                 {
-                    affectedPlayers.UnionWith(identity.observers);
+                    AddAll(affectedPlayers, identity.observers);
                     if (identity.hasPendingObservers)
-                        affectedPlayers.UnionWith(identity.pendingObservers);
+                        AddAll(affectedPlayers, identity.pendingObservers);
                     identity.ClearObservers();
                 }
             }
 
             return identities[0].directChildren;
+        }
+
+        private static void AddAll(HashSet<PlayerID> target, IReadOnlyList<PlayerID> players)
+        {
+            for (var i = 0; i < players.Count; i++)
+                target.Add(players[i]);
         }
 
         private void Notify(PlayerID player, Transform scope, bool isVisible)


### PR DESCRIPTION

<img width="1156" height="460" alt="image" src="https://github.com/user-attachments/assets/17aacc38-8aa6-4666-86d7-e093969b88f5" />


```C#
GC.Alloc
0,007ms

Current frame accumulated time:
0,822ms for 121 instances on thread 'Main Thread'
Size: 48
Call Stack:
mscorlib.dll!System.Collections.Generic::List`1.System.Collections.Generic.IEnumerable<T>.GetEnumerator()	<a href="<no-source>" line="1"><no-source>:1</a>
System.Core.dll!System.Collections.Generic::HashSet`1.UnionWith()	<a href="<no-source>" line="1"><no-source>:1</a>
PurrNet.Runtime.dll!PurrNet.Modules::VisilityV2.ClearNode()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/VisilityV2.cs" line="198">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/VisilityV2.cs:198</a>
PurrNet.Runtime.dll!PurrNet.Modules::VisilityV2.ClearObservers()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/VisilityV2.cs" line="168">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/VisilityV2.cs:168</a>
PurrNet.Runtime.dll!PurrNet.Modules::VisilityV2.ClearVisibilityForGameObject()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/VisilityV2.cs" line="125">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/VisilityV2.cs:125</a>
PurrNet.Runtime.dll!PurrNet.Modules::HierarchyV2.Despawn()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs" line="3219">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:3219</a>
PurrNet.Runtime.dll!PurrNet::NetworkIdentity.Despawn()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Components/NetworkIdentity/NetworkIdentity.cs" line="911">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Components/NetworkIdentity/NetworkIdentity.cs:911</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.OnDestroy()	<a href="<no-source>" line="1"><no-source>:1</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.Destroy()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs" line="613">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs:613</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::Projectile.End()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Projectile.cs" line="1224">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Projectile.cs:1224</a>
Assembly-CSharp.dll!::<EndAfterLifetime>d__81.MoveNext()	<a href="<no-source>" line="1"><no-source>:1</a>
UniTask.dll!Cysharp.Threading.Tasks::UniTaskCompletionSourceCore`1.TrySetResult()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTaskCompletionSource.cs" line="125">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTaskCompletionSource.cs:125</a>
UniTask.dll!::DelayPromise.MoveNext()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTask.Delay.cs" line="789">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTask.Delay.cs:789</a>
UniTask.dll!Cysharp.Threading.Tasks.Internal::PlayerLoopRunner.RunCore()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/Internal/PlayerLoopRunner.cs" line="153">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/Internal/PlayerLoopRunner.cs:153</a>

```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791561903&installation_model_id=20441&pr_number=312&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F312&signature=a5084360051069631ebdeadb569416aaa278e7273f90d083edc3b763ca20446d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->