### PR TITLE
perf: avoid closure alloc when clearing failed async observer roots

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using PurrNet.Logging;
@@ -797,6 +797,8 @@ namespace PurrNet.Modules
         private readonly Dictionary<SpawnID, PendingAsyncObserverSpawn> _pendingAsyncObservers = new();
         private readonly Dictionary<SpawnID, PendingAsyncObserverSpawn> _readyAsyncObservers = new();
         private readonly HashSet<(PlayerID player, NetworkID root)> _failedAsyncObserverRoots = new();
+        private NetworkID _failedAsyncObserverRootFilter;
+        private Predicate<(PlayerID player, NetworkID root)> _failedAsyncObserverRootPredicate;
         private readonly HashSet<SpawnID> _relayAsyncSpawns = new();
         private readonly HashSet<NetworkID> _failedAsyncSpawnRoots = new();
         private int _asyncVisibilityDepth;
@@ -4489,7 +4491,14 @@ namespace PurrNet.Modules
             if (_failedAsyncObserverRoots.Count == 0)
                 return;
 
-            _failedAsyncObserverRoots.RemoveWhere(pair => pair.root == root);
+            _failedAsyncObserverRootFilter = root;
+            _failedAsyncObserverRootPredicate ??= MatchesFailedAsyncObserverRootFilter;
+            _failedAsyncObserverRoots.RemoveWhere(_failedAsyncObserverRootPredicate);
+        }
+
+        private bool MatchesFailedAsyncObserverRootFilter((PlayerID player, NetworkID root) pair)
+        {
+            return pair.root == _failedAsyncObserverRootFilter;
         }
 
         internal void CleanupDestroyedIdentity(NetworkIdentity identity)


### PR DESCRIPTION
<img width="1384" height="477" alt="image" src="https://github.com/user-attachments/assets/c00d16dc-c506-4ea2-b749-ba083b8c40c7" />


```C#
GC.Alloc
0,003ms

Current frame accumulated time:
0,822ms for 121 instances on thread 'Main Thread'
Size: 40
Call Stack:
PurrNet.Runtime.dll!PurrNet.Modules::HierarchyV2.RemoveFailedAsyncObserverRoots()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs" line="4485">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:4485</a>
PurrNet.Runtime.dll!PurrNet.Modules::HierarchyV2.UnregisterIdentity()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs" line="4474">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:4474</a>
PurrNet.Runtime.dll!PurrNet.Modules::HierarchyV2.Despawn()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs" line="3219">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:3219</a>
PurrNet.Runtime.dll!PurrNet::NetworkIdentity.Despawn()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Components/NetworkIdentity/NetworkIdentity.cs" line="911">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Components/NetworkIdentity/NetworkIdentity.cs:911</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.OnDestroy()	<a href="<no-source>" line="1"><no-source>:1</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.Destroy()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs" line="613">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs:613</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::Projectile.End()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Projectile.cs" line="1224">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Projectile.cs:1224</a>
Assembly-CSharp.dll!::<EndAfterLifetime>d__81.MoveNext()	<a href="<no-source>" line="1"><no-source>:1</a>
UniTask.dll!Cysharp.Threading.Tasks::UniTaskCompletionSourceCore`1.TrySetResult()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTaskCompletionSource.cs" line="125">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTaskCompletionSource.cs:125</a>
UniTask.dll!::DelayPromise.MoveNext()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTask.Delay.cs" line="789">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTask.Delay.cs:789</a>
UniTask.dll!Cysharp.Threading.Tasks.Internal::PlayerLoopRunner.RunCore()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/Internal/PlayerLoopRunner.cs" line="153">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/Internal/PlayerLoopRunner.cs:153</a>

```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791562377&installation_model_id=20441&pr_number=313&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F313&signature=1d2a50df10c4ec768bba9fc4da1f8588dbb97c20a63b2cacec3f9525e5dbf072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->