### PR TITLE
perf: avoid boxing on scene id lookups

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneEqualityComparer.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneEqualityComparer.cs
@@ -1,5 +1,10 @@
 using System.Collections.Generic;
 using UnityEngine.SceneManagement;
+#if UNITY_6000_3_OR_NEWER
+using SceneHandle = UnityEngine.SceneManagement.SceneHandle;
+#else
+using SceneHandle = System.Int32;
+#endif
 
 namespace PurrNet.Modules
 {
@@ -14,11 +19,8 @@ namespace PurrNet.Modules
 
         public int GetHashCode(Scene obj)
         {
-#if UNITY_6000_5_OR_NEWER
-            return obj.handle.GetHashCode();
-#else
-            return obj.handle;
-#endif
+            SceneHandle handle = obj.handle;
+            return handle.GetHashCode();
         }
     }
 }

--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneEqualityComparer.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneEqualityComparer.cs
@@ -14,7 +14,11 @@ namespace PurrNet.Modules
 
         public int GetHashCode(Scene obj)
         {
+#if UNITY_6000_5_OR_NEWER
+            return obj.handle.GetHashCode();
+#else
             return obj.handle;
+#endif
         }
     }
 }

--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneEqualityComparer.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneEqualityComparer.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using UnityEngine.SceneManagement;
+
+namespace PurrNet.Modules
+{
+    internal readonly struct SceneEqualityComparer : IEqualityComparer<Scene>
+    {
+        public static readonly SceneEqualityComparer instance = new SceneEqualityComparer();
+
+        public bool Equals(Scene a, Scene b)
+        {
+            return a.handle == b.handle;
+        }
+
+        public int GetHashCode(Scene obj)
+        {
+            return obj.handle;
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneEqualityComparer.cs.meta
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneEqualityComparer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e0ad557dce594f188c76eca8f1c65795
+timeCreated: 1788970751

--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
@@ -65,7 +65,7 @@ namespace PurrNet.Modules
         private readonly Queue<SceneAction> _actionsQueue = new Queue<SceneAction>();
 
         private readonly Dictionary<SceneID, SceneState> _scenes = new Dictionary<SceneID, SceneState>();
-        private readonly Dictionary<Scene, SceneID> _idToScene = new Dictionary<Scene, SceneID>();
+        private readonly Dictionary<Scene, SceneID> _idToScene = new Dictionary<Scene, SceneID>(SceneEqualityComparer.instance);
         private readonly List<SceneID> _rawScenes = new List<SceneID>();
         private readonly HashSet<SceneID> _sceneActionScenes = new HashSet<SceneID>();
 


### PR DESCRIPTION

```C#
GC.Alloc
0,011ms

Current frame accumulated time:
0,313ms for 74 instances on thread 'Main Thread'
Size: 24
Call Stack:
mscorlib.dll!System.Collections.Generic::ObjectEqualityComparer`1.Equals()	<a href="<no-source>" line="1"><no-source>:1</a>
mscorlib.dll!System.Collections.Generic::Dictionary`2.FindEntry()	<a href="<no-source>" line="1"><no-source>:1</a>
mscorlib.dll!System.Collections.Generic::Dictionary`2.TryGetValue()	<a href="<no-source>" line="1"><no-source>:1</a>
PurrNet.Runtime.dll!PurrNet::InstantiateData`1.TryGetHierarchy()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/InstantiateData.cs" line="133">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/InstantiateData.cs:133</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.OnPreInstantiate()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs" line="765">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs:765</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.Instantiate()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs" line="794">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs:794</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::Spell.SpawnProjectile()	<a href="<no-source>" line="1"><no-source>:1</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::Spell.FireProjectile()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs" line="652">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs:652</a>
Assembly-CSharp.dll!::<FireVolley>d__29.MoveNext()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs" line="518">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs:518</a>
UniTask.dll!Cysharp.Threading.Tasks::UniTaskCompletionSourceCore`1.TrySetResult()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTaskCompletionSource.cs" line="125">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTaskCompletionSource.cs:125</a>
UniTask.dll!::DelayPromise.MoveNext()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTask.Delay.cs" line="789">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/UniTask.Delay.cs:789</a>
UniTask.dll!Cysharp.Threading.Tasks.Internal::PlayerLoopRunner.RunCore()	<a href="./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/Internal/PlayerLoopRunner.cs" line="153">./Library/PackageCache/com.cysharp.unitask@360e370345b9/Runtime/Internal/PlayerLoopRunner.cs:153</a>
```


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791562820&installation_model_id=20441&pr_number=314&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F314&signature=30a5008c3dffb8f29aba8c58ce000063b4dbbeaff11564de90d2d2e06e691061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->