### PR TITLE
perf: reuse direct children list in PreparePrefabInfo

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -173,7 +173,11 @@ namespace PurrNet
             firstIdentity.InvalidateSiblingIdentities();
 
             if (firstIdentity != this)
-                _directChildren = new List<NetworkIdentity>();
+            {
+                if (_directChildren == null)
+                    _directChildren = new List<NetworkIdentity>();
+                else _directChildren.Clear();
+            }
             else RecalculateDirectChildren();
         }
 


### PR DESCRIPTION
`PreparePrefabInfo` allocated a fresh empty `List<NetworkIdentity>` for every non-root identity in the hierarchy, discarding the one the component already had. On a prefab instantiate this showed up in the profiler as 167 x 40 B of `GC.Alloc` under `NetworkManager.SetupPrefabInfo` -> `NetworkIdentity.PreparePrefabInfo`, per spawn.

The list is only ever needed empty at this point, so reuse it and clear it when one already exists - matching what `RecalculateDirectChildren` already does. Only the first-ever setup of an identity with a null list still allocates.


<img width="1183" height="524" alt="image" src="https://github.com/user-attachments/assets/76b462e9-90c4-4361-8634-2a3beda17282" />


```C#
GC.Alloc
0,007ms

Current frame accumulated time:
0,892ms for 167 instances on thread 'Main Thread'
Size: 40
Call Stack:
PurrNet.Runtime.dll!PurrNet::NetworkIdentity.PreparePrefabInfo()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Components/NetworkIdentity/NetworkIdentity.cs" line="149">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Components/NetworkIdentity/NetworkIdentity.cs:149</a>
PurrNet.Runtime.dll!PurrNet::NetworkManager.SetupPrefabInfo()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Managers/NetworkManager.cs" line="559">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Managers/NetworkManager.cs:559</a>
PurrNet.Runtime.dll!PurrNet::NetworkManager.SetupPrefabInfo()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Managers/NetworkManager.cs" line="540">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/Managers/NetworkManager.cs:540</a>
PurrNet.Runtime.dll!PurrNet.Modules::HierarchyV2.OnGameObjectCreated()	<a href="<no-source>" line="1"><no-source>:1</a>
PurrNet.Runtime.dll!PurrNet.Modules::PurrNetGameObjectUtils.NotifyGameObjectCreated()	<a href="<no-source>" line="1"><no-source>:1</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.OnPreInstantiate()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs" line="765">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs:765</a>
PurrNet.Runtime.dll!PurrNet::UnityProxy.Instantiate()	<a href="./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs" line="794">./Library/PackageCache/dev.purrnet.purrnet@e617d4ee90f0/Runtime/UnityProxy/UnityProxy.cs:794</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::Spell.SpawnProjectile()	<a href="<no-source>" line="1"><no-source>:1</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::Spell.FireProjectile()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs" line="652">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs:652</a>
Assembly-CSharp.dll!::<FireVolley>d__29.MoveNext()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs" line="518">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs:518</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::Spell.FireVolley()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs" line="711">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/Spell.cs:711</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft.Spells::FireboltSpell.OnExecute()	<a href="<no-source>" line="1"><no-source>:1</a>
Assembly-CSharp.dll!::<RunCast>d__84.MoveNext()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/SpellcasterComponent.cs" line="112">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/SpellcasterComponent.cs:112</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::SpellcasterComponent.TryCastInternal()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/SpellcasterComponent.cs" line="472">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/SpellcasterComponent.cs:472</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::SpellcasterComponent.TryCast()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/SpellcasterComponent.cs" line="293">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/SpellcasterComponent.cs:293</a>
Assembly-CSharp.dll!TLM.Modules.Spellcraft::SpellcasterComponent.AutoAttack()	<a href="C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/SpellcasterComponent.cs" line="365">C:/Users/joao_/Documentos/GitHub/tlm/Assets/Modules/Spellcraft/SpellcasterComponent.cs:365</a>
Assembly-CSharp.dll!TLM.Modules.Behavior::CastSpellAction.OnStart()	<a href="<no-source>" line="1"><no-source>:1</a>
Unity.Behavior.dll!Unity.Behavior::BehaviorGraphModule.StartNode()	<a href="./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/BehaviorGraphModule.cs" line="124">./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/BehaviorGraphModule.cs:124</a>
Unity.Behavior.dll!Unity.Behavior::AbortModifier.OnStart()	<a href="./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/Nodes/Decorators/Aborts/AbortModifier.cs" line="47">./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/Nodes/Decorators/Aborts/AbortModifier.cs:47</a>
Unity.Behavior.dll!Unity.Behavior::BehaviorGraphModule.StartNode()	<a href="./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/BehaviorGraphModule.cs" line="124">./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/BehaviorGraphModule.cs:124</a>
Unity.Behavior.dll!Unity.Behavior::SequenceComposite.OnUpdate()	<a href="./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/Nodes/Composites/SequenceComposite.cs" line="24">./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/Nodes/Composites/SequenceComposite.cs:24</a>
Unity.Behavior.dll!Unity.Behavior::BehaviorGraphModule.Tick()	<a href="./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/BehaviorGraphModule.cs" line="66">./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/BehaviorGraphModule.cs:66</a>
Unity.Behavior.dll!Unity.Behavior::BehaviorGraphAgent.Update()	<a href="./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/Components/BehaviorGraphAgent.cs" line="721">./Library/PackageCache/com.unity.behavior@1b9c0eccba9c/Runtime/Execution/Components/BehaviorGraphAgent.cs:721</a>

````
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791563188&installation_model_id=20441&pr_number=315&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F315&signature=bf667641d3c385006c113701846032af6897cb78bb8410c6c935391244da4b77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->